### PR TITLE
Added iter\reindex and iter\fn\path

### DIFF
--- a/src/iter.fn.php
+++ b/src/iter.fn.php
@@ -71,3 +71,45 @@ function not($function) {
         return !call_user_func_array($function, func_get_args());
     };
 }
+
+/**
+ * Returns a callable which returns an item from a (nested) associative array
+ * corresponding to the given path.
+ *
+ * Useful in conjunction with iter\reindex.
+ *
+ * Examples:
+ *     $security = [
+ *         'seccode' => 'HT-R-A',
+ *         'isin' => 'HRHT00RA0005',
+ *         'issuer' => [
+ *             'code' => 'HT',
+ *             'name' => 'Hrvatski Telekom d.d.'
+ *         ],
+ *     ];
+ *
+ *     $path = path('issuer', 'code');
+ *
+ *     $path($security);
+ *     => "HT"
+ */
+function path() {
+    $path = func_get_args();
+
+    return function($array) use ($path) {
+        foreach ($path as $key) {
+            if (!is_scalar($key)) {
+                throw new \InvalidArgumentException("Path item not scalar.");
+            }
+            if (isset($array[$key])) {
+                $array = $array[$key];
+            } else {
+                $path = implode(' > ', $path);
+                $msg = sprintf("Path \"%s\" not found in array.", $path);
+                throw new \InvalidArgumentException($msg);
+            }
+        }
+
+        return $array;
+    };
+}

--- a/src/iter.php
+++ b/src/iter.php
@@ -499,6 +499,31 @@ function flatten($iterable) {
     }
 }
 
+/**
+ * Reindexes an iterable. Keys are calculated based on values. Takes an iterable
+ * and a callable which, when run with the value as argument, provides the key
+ * for that iteration.
+ *
+ * Examples:
+ *
+ *      $keyFn = function($value) {
+ *          return strtoupper($value);
+ *      };
+ *      iter\reindex(["a", "b", "c"], $keyFn);
+ *      => iter("A" => "a", "B" => "b", "C" => "c")
+ */
+function reindex($iterable, callable $keyFn) {
+    foreach ($iterable as $value) {
+        $key = $keyFn($value);
+
+        if (!is_scalar($key)) {
+            throw new \InvalidArgumentException("keyFn did not return a valid key.");
+        }
+
+        yield $key => $value;
+    }
+}
+
 function count($iterable) {
     if (is_array($iterable) || $iterable instanceof \Countable) {
         return \count($iterable);

--- a/test/IterFnTest.php
+++ b/test/IterFnTest.php
@@ -95,6 +95,46 @@ class IterFnTest extends \PHPUnit_Framework_TestCase {
     public function testInvalidOperator() {
         fn\operator('**');
     }
+
+    public function testPath()
+    {
+        $array = [
+            'foo' => 1,
+            'bar' => [
+                'baz' => 2
+            ]
+        ];
+
+        $path1 = fn\path('foo');
+        $path2 = fn\path('bar');
+        $path3 = fn\path('bar', 'baz');
+
+        $this->assertSame(1, $path1($array));
+        $this->assertSame(['baz' => 2], $path2($array));
+        $this->assertSame(2, $path3($array));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Path "foo > bar" not found in array.
+     */
+    public function testPathDoesNotExist()
+    {
+        $array = ['foo' => 1];
+        $path = fn\path('foo', 'bar');
+        $path($array);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Path item not scalar.
+     */
+    public function testPathContainsNonScalar()
+    {
+        $array = ['foo' => 1];
+        $path = fn\path(array());
+        $path($array);
+    }
 }
 
 class _MethodTestDummy {

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -181,4 +181,34 @@ class IterTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(5, count([1, 2, 3, 4, 5]));
         $this->assertEquals(5, count(toIter([1, 2, 3, 4, 5])));
     }
+
+    public function testReindex() {
+        $keyFn = function($value) {
+            return strtoupper($value);
+        };
+        $iter = reindex(["a", "b", "c", "d", "e"], $keyFn);
+        $expected = ["A" => "a", "B" => "b", "C" => "c", "D" => "d", "E" => "e"];
+        $this->assertEquals($expected, toArrayWithKeys($iter));
+
+        $keyFn = function($value) {
+            return $value * 2;
+        };
+        $iter = reindex([1, 2, 3, 4], $keyFn);
+        $expected = [2 => 1, 4 => 2, 6 => 3, 8 => 4];
+        $this->assertEquals($expected, toArrayWithKeys($iter));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage keyFn did not return a valid key
+     */
+    public function testReindexKeyMustBeScalar()
+    {
+        $keyFn = function($value) {
+            return array();
+        };
+
+        $iter = reindex([1, 2, 3], $keyFn);
+        toArrayWithKeys($iter);
+    }
 }


### PR DESCRIPTION
These two solve a use case which i often have.

You have a nested associative array like this:

``` php
$securities = [
    [
        'seccode' => 'HT-R-A',
        'isin' => 'HRHT00RA0005',
        'issuer' => [
            'code' => 'HT',
            'name' => 'Hrvatski Telekom d.d.'
        ],
    ],
    [
        'seccode' => 'INGR-O-11CA',
        'isin' => 'HRINGRO11CA1',
        'issuer' => [
            'code' => 'INGR',
            'name' => 'Ingra d.d.'
        ],
    ]
];
```

And you want to iterate over it, but with the key being a value from the array.

``` php
$path = iter\fn\path('issuer', 'code');
$iter = iter\reindex($securities, $path);
foreach(iter\keys($iter) as $key) {
    var_dump($key);
}
```

This yields:

``` php
string(2) "HT"
string(4) "INGR"
```
