### PR TITLE
Chunk function to return an Iterator of Iterable chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ list the function signatures as an overview:
     Iterator dropWhile(callable $predicate, iterable $iterable)
     Iterator flatten(iterable $iterable)
     int      count(iterable $iterable)
+    Iterator chunk(iterable $iterable, int $size)
     Iterator toIter(iterable $iterable)
     array    toArray(iterable $iterable)
     array    toArrayWithKeys(iterable $iterable)

--- a/src/iter.php
+++ b/src/iter.php
@@ -532,6 +532,40 @@ function count($iterable) {
 }
 
 /**
+ * Takes an iterable and chunks it into the specified size.
+ * 
+ * This function yields arrays of the specified size
+ * 
+ * Examples:
+ * 
+ *      iter\chunk([1, 2, 3], 2)
+ *      => iter([1, 2], [3])
+ * 
+ * @param $iterable The iterable to chunk
+ * @param $size The size of each chunk
+ * @return \Iterator An iterator of arrays
+ */
+function chunk($iterable, $size) {
+    $chunk = [];
+    $count = 0;
+
+    foreach ($iterable as $key => $value) {
+        $chunk[$key] = $value;
+        $count++;
+        
+        if ($count === $size) {
+            yield $chunk;
+            $count = 0;
+            $chunk = [];
+        }
+    }
+    
+    if ($count !== 0) {
+        yield $chunk;
+    }
+}
+
+/**
  * Converts any iterable into an Iterator.
  *
  * Examples:

--- a/src/iter.rewindable.php
+++ b/src/iter.rewindable.php
@@ -67,6 +67,7 @@ namespace iter\rewindable {
     function keys()        { return new _RewindableGenerator('iter\keys',        func_get_args()); }
     function values()      { return new _RewindableGenerator('iter\values',      func_get_args()); }
     function flatten()     { return new _RewindableGenerator('iter\flatten',     func_get_args()); }
+    function chunk()       { return new _RewindableGenerator('iter\chunk',       func_get_args()); }
 
     /**
      * This class is used for the internal implementation of rewindable

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -203,6 +203,21 @@ class IterTest extends \PHPUnit_Framework_TestCase {
             toArrayWithKeys(chain(['a' => 1, 'b' => 2], ['a' => 3]))
         );
     }
+
+    public function testChunk() {
+        $iterable = new \ArrayIterator(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5, 'f' => 6, 'g' => 7]);
+
+        $str = '';
+
+        foreach (chunk($iterable, 2) as $chunk) {
+            foreach ($chunk as $key => $value) {
+                $str .= sprintf('%s:%s ', $key, $value);
+            }
+            $str .= "\n";
+        }
+
+        $this->assertEquals("a:1 b:2 \nc:3 d:4 \ne:5 f:6 \ng:7 \n", $str);
+    }
 }
 
 class _CountableTestDummy implements \Countable {


### PR DESCRIPTION
 Takes an iterable and chunks it into the specified size.

 This function is lazy in that it yields each chunk as a generator
 which when iterated will yield size times or until the iterator is
 no longer valid

 Examples:

```
  iter\chunk([1, 2, 3], 2)
  => iter(iter(1, 2), iter(3))
```
