### PR TITLE
Support for implode on iterators

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ list the function signatures as an overview:
     Iterator toIter(iterable $iterable)
     array    toArray(iterable $iterable)
     array    toArrayWithKeys(iterable $iterable)
+    string   implode(iterable $iterable, $glue)
 
 As the functionality is implemented using generators the resulting iterators
 are by default not rewindable. This library implements additional functionality

--- a/src/iter.php
+++ b/src/iter.php
@@ -610,6 +610,32 @@ function toArrayWithKeys($iterable) {
     return $array;
 }
 
+/**
+ * Takes an iterable and joins its elements with a string
+ *
+ * Examples:
+ * 
+ *      iter\implode(new \ArrayIterator(['a', 'b', 'c']), ',')
+ *      => "a,b,c"
+ * 
+ * @param $iterable
+ * @param $glue
+ * @return string
+ */
+function implode($iterable, $glue) {
+    $str = '';
+    $first = true;
+    foreach ($iterable as $value) {
+        if ($first) {
+            $str .= $value;
+            $first = false;
+        } else {
+            $str .= $glue . $value;
+        }
+    }
+    return $str;
+}
+
 /*
  * Python:
  * compress()

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -203,6 +203,13 @@ class IterTest extends \PHPUnit_Framework_TestCase {
             toArrayWithKeys(chain(['a' => 1, 'b' => 2], ['a' => 3]))
         );
     }
+    
+    public function testImplode() {
+        $this->assertEquals(
+            "a,b,c",
+            implode(new \ArrayIterator(['a', 'b', 'c']), ',')
+        );
+    }
 }
 
 class _CountableTestDummy implements \Countable {


### PR DESCRIPTION
 Takes an iterable and joins its elements with a string

 Examples:

```
  iter\implode(new \ArrayIterator(['a', 'b', 'c']), ',')
  => "a,b,c"
```
