### PR TITLE
Support for mapKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ list the function signatures as an overview:
 
     Iterator range(number $start, number $end, number $step = null)
     Iterator map(callable $function, iterable $iterable)
+    Iterator mapKeys(callable $function, iterable $iterable)
     void     apply(callable $function, iterable $iterable)
     Iterator filter(callable $predicate, iterable $iterable)
     mixed    reduce(callable $function, iterable $iterable, mixed $startValue = null)

--- a/src/iter.php
+++ b/src/iter.php
@@ -85,6 +85,29 @@ function map(callable $function, $iterable) {
 }
 
 /**
+ * Applies a mapping function to all keys of an iterator.
+ *
+ * The function is passed the current iterator key and should return a
+ * modified iterator key. The value is left as-is and not passed to the mapping
+ * function.
+ *
+ * Examples:
+ *
+ *     iter\mapKeys('strtolower', ['A' => 1, 'B' => 2, 'C' => 3, 'D' => 4]);
+ *     => iter('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4)
+ *
+ * @param callable $function Mapping function: mixed function(mixed $key)
+ * @param mixed    $iterable Iterable to be mapped over
+ *
+ * @return \Iterator
+ */
+function mapKeys(callable $function, $iterable) {
+    foreach ($iterable as $key => $value) {
+        yield $function($key) => $value;
+    }
+}
+
+/**
  * Applies a function to all values of an iterable.
  *
  * The function is passed the current iterator value. The reason why apply

--- a/src/iter.rewindable.php
+++ b/src/iter.rewindable.php
@@ -54,6 +54,7 @@ namespace iter\rewindable {
 
     function range()       { return new _RewindableGenerator('iter\range',       func_get_args()); }
     function map()         { return new _RewindableGenerator('iter\map',         func_get_args()); }
+    function mapKeys()     { return new _RewindableGenerator('iter\mapKeys',     func_get_args()); }
     function filter()      { return new _RewindableGenerator('iter\filter',      func_get_args()); }
     function zip()         { return new _RewindableGenerator('iter\zip',         func_get_args()); }
     function zipKeyValue() { return new _RewindableGenerator('iter\zipKeyValue', func_get_args()); }

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -42,6 +42,12 @@ class IterTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame([0, 3, 6, 9, 12, 15], toArray($mapped));
     }
 
+    public function testMapKeys() {
+        $range = range(0, 5);
+        $mapped = mapKeys(function($n) { return $n * 3; }, $range);
+        $this->assertSame([0 => 0, 3 => 1, 6 => 2, 9 => 3, 12 => 4, 15 => 5], toArrayWithKeys($mapped));
+    }
+
     public function testApply() {
         $range = range(0, 5);
         $result = [];


### PR DESCRIPTION
 Applies a mapping function to all keys of an iterator.

 The function is passed the current iterator key and should return a
 modified iterator key. The value is left as-is and not passed to the mapping
 function.

 Examples:

```
 iter\map('strtolower', ['A' => 1, 'B' => 2, 'C' => 3, 'D' => 4]);
 => iter('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4)
```
