### PR TITLE
Support for flip

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ list the function signatures as an overview:
     Iterator toIter(iterable $iterable)
     array    toArray(iterable $iterable)
     array    toArrayWithKeys(iterable $iterable)
+    Iterator flip(iterable $iterable)
 
 As the functionality is implemented using generators the resulting iterators
 are by default not rewindable. This library implements additional functionality

--- a/src/iter.php
+++ b/src/iter.php
@@ -610,6 +610,23 @@ function toArrayWithKeys($iterable) {
     return $array;
 }
 
+/**
+ * Takes and iterator and yields its keys and values flipped
+ * 
+ * Examples:
+ * 
+ *      iter\flip(new ArrayIterator(['a' => 1, 'b' => 2, 'c' => 3]))
+ *      => iter(1 => 'a', 2 => 'b', 3 => 'c')
+ * 
+ * @param $iterable
+ * @return \Iterator
+ */
+function flip($iterable) {
+    foreach ($iterable as $key => $value) {
+        yield $value => $key;
+    }
+}
+
 /*
  * Python:
  * compress()

--- a/src/iter.rewindable.php
+++ b/src/iter.rewindable.php
@@ -67,6 +67,7 @@ namespace iter\rewindable {
     function keys()        { return new _RewindableGenerator('iter\keys',        func_get_args()); }
     function values()      { return new _RewindableGenerator('iter\values',      func_get_args()); }
     function flatten()     { return new _RewindableGenerator('iter\flatten',     func_get_args()); }
+    function flip()        { return new _RewindableGenerator('iter\flip',        func_get_args()); }
 
     /**
      * This class is used for the internal implementation of rewindable

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -203,6 +203,13 @@ class IterTest extends \PHPUnit_Framework_TestCase {
             toArrayWithKeys(chain(['a' => 1, 'b' => 2], ['a' => 3]))
         );
     }
+    
+    public function testFlip() {
+        $this->assertSame(
+            [1 => 'a', 2 => 'b', 3 => 'c'],
+            toArrayWithKeys(flip(['a' => 1, 'b' => 2, 'c' => 3]))
+        );
+    }
 }
 
 class _CountableTestDummy implements \Countable {


### PR DESCRIPTION
 Takes and iterator and yields its keys and values flipped

 Examples:

```
  iter\flip(new ArrayIterator(['a' => 1, 'b' => 2, 'c' => 3]))
  => iter(1 => 'a', 2 => 'b', 3 => 'c')
```
