### PR TITLE
Recursive cousins for toArray and toArrayWithKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ list the function signatures as an overview:
     Iterator toIter(iterable $iterable)
     array    toArray(iterable $iterable)
     array    toArrayWithKeys(iterable $iterable)
+    array    toArrayRecursive(iterable $iterable)
+    array    toArrayRecursiveWithKeys(iterable $iterable)
     Iterator flip(iterable $iterable)
 
 As the functionality is implemented using generators the resulting iterators

--- a/src/iter.php
+++ b/src/iter.php
@@ -628,6 +628,60 @@ function toArrayWithKeys($iterable) {
     return $array;
 }
 
+/**
+ * Recursively converts iterables into arrays, without preserving keys.
+ *
+ * Each traversable value that is encountered turned into an array recursively
+ *
+ * Examples:
+ *
+ *      iter\toArrayRecursive(new \ArrayIterator([new \ArrayIterator([1, 2, 3]), 2, 3]))
+ *      => [[1, 2, 3], 2, 3]
+ *
+ * @param mixed $iterable The iterable to convert to an array
+ *
+ * @return array
+ */
+function toArrayRecursive($iterable) {
+    $array = [];
+    foreach ($iterable as $value) {
+        if ($value instanceof \Traversable) {
+            $array[] = toArrayRecursive($value);
+        } else {
+            $array[] = $value;
+        }
+    }
+    return $array;
+}
+
+/**
+ * Recursively converts iterables into arrays preserving their keys.
+ *
+ * Each traversable value that is encountered turned into an array recursively
+ *
+ * Examples:
+ *
+ *      iter\toArrayRecursiveWithKeys(
+ *          new \ArrayIterator(['a' => new \ArrayIterator(['a' => 1, 'b' => 2, 'c' => 3]), 'c' => 2, 'c' => 3])
+ *      )
+ *      => ['a' => ['a' => 1,'b' => 2, 'c' => 3], 'b' => 2, 'c' => 3]
+ *
+ * @param mixed $iterable The iterable to convert to an array
+ * 
+ * @return array
+ */
+function toArrayRecursiveWithKeys($iterable) {
+    $array = [];
+    foreach ($iterable as $key => $value) {
+        if ($value instanceof \Traversable) {
+            $array[$key] = toArrayRecursiveWithKeys($value);
+        } else {
+            $array[$key] = $value;
+        }
+    }
+    return $array;
+}
+
 /*
  * Python:
  * compress()

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -189,6 +189,27 @@ class IterTest extends \PHPUnit_Framework_TestCase {
         );
     }
 
+    public function testToArrayRecursive() {
+        $this->assertSame(
+            [[[1, 2, 3], 2, 3], 2, 3],
+            toArrayRecursive(
+                new \ArrayIterator([
+                    'a' => new \ArrayIterator([
+                        'a' => new \ArrayIterator([
+                            'a' => 1,
+                            'b' => 2,
+                            'c' => 3
+                        ]),
+                        'b' => 2,
+                        'c' => 3
+                    ]),
+                    'b' => 2,
+                    'c' => 3
+                ])
+            )
+        );
+    }
+
     public function testToArrayWithKeys() {
         $this->assertSame(
             ['a' => 1, 'b' => 2, 'c' => 3],
@@ -201,6 +222,27 @@ class IterTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame(
             ['a' => 3, 'b' => 2],
             toArrayWithKeys(chain(['a' => 1, 'b' => 2], ['a' => 3]))
+        );
+    }
+
+    public function testToArrayRecursiveWithKeys() {
+        $this->assertSame(
+            ['a' => ['a' => ['a' => 1, 'b' => 2, 'c' => 3], 'b' => 2, 'c' => 3], 'b' => 2, 'c' => 3],
+            toArrayRecursiveWithKeys(
+                new \ArrayIterator([
+                    'a' => new \ArrayIterator([
+                            'a' => new \ArrayIterator([
+                                    'a' => 1,
+                                    'b' => 2,
+                                    'c' => 3
+                                ]),
+                            'b' => 2,
+                            'c' => 3
+                        ]),
+                    'b' => 2,
+                    'c' => 3
+                ])
+            )
         );
     }
     


### PR DESCRIPTION
 Recursively converts iterables into arrays, without preserving keys.

 Each traversable value that is encountered turned into an array recursively

 Examples:

      iter\toArrayRecursive(new \ArrayIterator([new \ArrayIterator([1, 2, 3]), 2, 3]))
      => [[1, 2, 3], 2, 3]

 Recursively converts iterables into arrays preserving their keys.

 Each traversable value that is encountered turned into an array recursively

 Examples:

      iter\toArrayRecursiveWithKeys(
          new \ArrayIterator(['a' => new \ArrayIterator(['a' => 1, 'b' => 2, 'c' => 3]), 'c' => 2, 'c' => 3])
      )
      => ['a' => ['a' => 1,'b' => 2, 'c' => 3], 'b' => 2, 'c' => 3]