### PR TITLE
reductions(), intermediate values of a reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ list the function signatures as an overview:
     Iterator mapKeys(callable $function, iterable $iterable)
     Iterator reindex(callable $function, iterable $iterable)
     Iterator filter(callable $predicate, iterable $iterable)
+    Iterator reductions(callable $function, iterable $iterable, mixed $startValue = null)
     Iterator zip(iterable... $iterables)
     Iterator zipKeyValue(iterable $keys, iterable $values)
     Iterator chain(iterable... $iterables)

--- a/src/iter.php
+++ b/src/iter.php
@@ -217,6 +217,38 @@ function reduce(callable $function, $iterable, $startValue = null) {
 }
 
 /**
+ * Intermediate values of reducing iterable using a function.
+ *
+ * The reduction function is passed an accumulator value and the current
+ * iterator value and returns a new accumulator. The accumulator is initialized
+ * to $startValue.
+ *
+ * Reductions yield each accumulator along the way.
+ *
+ * Examples:
+ *
+ *      reductions(fn\operator('+'), range(1, 5), 0)
+ *      => iter(1, 3, 6, 10, 15)
+ *      reductions(fn\operator('*'), range(1, 5), 1)
+ *      => iter(1, 2, 6, 24, 120)
+ *
+ * @param callable $function   Reduction function:
+ *                             mixed function(mixed $acc, mixed $value)
+ * @param mixed    $iterable   Iterable to reduce
+ * @param mixed    $startValue Start value for accumulator. Usually identity
+ *                             value of $function.
+ *
+ * @return mixed Intermediate results of the reduction
+ */
+function reductions(callable $function, $iterable, $startValue = null) {
+    $acc = $startValue;
+    foreach ($iterable as $value) {
+        $acc = $function($acc, $value);
+        yield $acc;
+    }
+}
+
+/**
  * Zips the iterables that were passed as arguments.
  *
  * Afterwards keys and values will be arrays containing the keys/values of

--- a/src/iter.rewindable.php
+++ b/src/iter.rewindable.php
@@ -57,6 +57,7 @@ namespace iter\rewindable {
     function mapKeys()     { return new _RewindableGenerator('iter\mapKeys',     func_get_args()); }
     function reindex()     { return new _RewindableGenerator('iter\reindex',     func_get_args()); }
     function filter()      { return new _RewindableGenerator('iter\filter',      func_get_args()); }
+    function reductions()  { return new _RewindableGenerator('iter\reductions',  func_get_args()); }
     function zip()         { return new _RewindableGenerator('iter\zip',         func_get_args()); }
     function zipKeyValue() { return new _RewindableGenerator('iter\zipKeyValue', func_get_args()); }
     function chain()       { return new _RewindableGenerator('iter\chain',       func_get_args()); }

--- a/test/IterRewindableTest.php
+++ b/test/IterRewindableTest.php
@@ -39,6 +39,10 @@ class IterRewindableTest extends \PHPUnit_Framework_TestCase {
             rewindable\zip(rewindable\range(0, 5), rewindable\range(5, 0, -1))
         );
         $this->assertRewindableEquals(
+            [1, 3, 6, 10, 15],
+            rewindable\reductions(fn\operator('+'), rewindable\range(1, 5), 0)
+        );
+        $this->assertRewindableEquals(
             [5=>0, 4=>1, 3=>2, 2=>3, 1=>4, 0=>5],
             rewindable\zipKeyValue(rewindable\range(5, 0, -1), rewindable\range(0, 5)),
             true

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -134,6 +134,11 @@ class IterTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame(120, reduce(fn\operator('*'), range(1, 5), 1));
     }
 
+    public function testReductions() {
+        $this->assertSame([1, 3, 6, 10, 15], toArrayWithKeys(reductions(fn\operator('+'), range(1, 5), 0)));
+        $this->assertSame([1, 2, 6, 24, 120], toArrayWithKeys(reductions(fn\operator('*'), range(1, 5), 1)));
+    }
+
     public function testAnyAll() {
         $this->assertTrue(all(fn\operator('>', 0), range(1, 10)));
         $this->assertFalse(all(fn\operator('>', 0), range(-5, 5)));


### PR DESCRIPTION
reductions() is quite similar to reduce(). However, instead of only
returning the final result, it will yield every accumulated value
along the way.

This is taken from clojure's reductions() function:
- https://clojuredocs.org/clojure.core/reductions
