### PR TITLE
Add failing test for slice() iterating too much

### DIFF
--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -109,6 +109,11 @@ class IterTest extends \PHPUnit_Framework_TestCase {
             [5, 6, 7, 8, 9],
             toArray(slice(range(0, 9), 5))
         );
+        $explodingGenerator = function () {
+            yield 1;
+            throw new \RuntimeException('This should only be iterated once');
+        };
+        $this->assertSame([1], toArray(slice($explodingGenerator(), 0, 1)));
     }
 
     public function testTakeDrop() {


### PR DESCRIPTION
I was expecting slice() to not iterate further if its limit value is 1 and it already found a value.

I have added a failing test for if this really is undesired behavior.