### PR TITLE
Fixed bug with zip on empty parameters

### DIFF
--- a/src/iter.php
+++ b/src/iter.php
@@ -277,6 +277,9 @@ function reductions(callable $function, $iterable, $startValue = null) {
  */
 function zip(/* ...$iterables */) {
     $iterables = func_get_args();
+    if (count($iterables) === 0) {
+        return;
+    }
     _assertAllIterable($iterables);
 
     $iterators = array_map('iter\\toIter', $iterables);

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -90,6 +90,11 @@ class IterTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame([[0,5], [1,4], [2,3], [3,2], [4,1], [5,0]], toArray($zipped));
     }
 
+    public function testZipEmpty() {
+        $res = toArray(zip());
+        $this->assertSame([], $res);
+    }
+
     public function testZipKeyValue() {
         $zipped = zipKeyValue(range(5, 0, -1), range(0, 5));
         $this->assertSame([5=>0, 4=>1, 3=>2, 2=>3, 1=>4, 0=>5], toArrayWithKeys($zipped));


### PR DESCRIPTION
If you called zip with empty paremeters it would
cause an infinite loop.

Added a check if the parameters where empty to
avoid this scenario

I know it seems odd to even test for this case because calling `zip()` seems like invalid behavior, but in php 5.6 you can get the same result by unpacking an array into arguments `zip(...[])`. If the iterator is empty, it will cause zip to loop infinitely.

Signed-off-by: RJ Garcia <rj@bighead.net>