### PR TITLE
Support PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0"
+        "phpunit/phpunit": "~5.7 || ~6.4"
     },
     "autoload": {
         "files": ["src/bootstrap.php"]

--- a/test/IterFnTest.php
+++ b/test/IterFnTest.php
@@ -3,8 +3,9 @@
 namespace iter;
 
 use iter\fn;
+use PHPUnit\Framework\TestCase;
 
-class IterFnTest extends \PHPUnit_Framework_TestCase {
+class IterFnTest extends TestCase {
     public function testIndex() {
         $getIndex3 = fn\index(3);
         $getIndexTest = fn\index('test');

--- a/test/IterRewindableTest.php
+++ b/test/IterRewindableTest.php
@@ -3,8 +3,9 @@
 namespace iter;
 
 use iter\rewindable;
+use PHPUnit\Framework\TestCase;
 
-class IterRewindableTest extends \PHPUnit_Framework_TestCase {
+class IterRewindableTest extends TestCase {
     private function assertRewindableEquals($array, $iter, $withKeys = false) {
         $fn = $withKeys ? 'iter\\toArrayWithKeys' : 'iter\\toArray';
         $this->assertSame($array, $fn($iter));

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -2,7 +2,9 @@
 
 namespace iter;
 
-class IterTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class IterTest extends TestCase {
     /** @dataProvider provideTestRange */
     public function testRange($start, $end, $step, $resultArray) {
         $this->assertSame($resultArray, toArray(range($start, $end, $step)));
@@ -453,10 +455,12 @@ class IterTest extends \PHPUnit_Framework_TestCase {
         $this->assertFalse(isIterable(123));
     }
 
-    /** @dataProvider provideTestAssertIterableFails */
+    /**
+     * @dataProvider provideTestAssertIterableFails
+     * @expectedException \InvalidArgumentException
+     */
     public function testAssertIterableFails(callable $fn, $expectedMessage) {
-        $this->setExpectedException(
-            \InvalidArgumentException::class, $expectedMessage);
+        $this->expectExceptionMessage($expectedMessage);
         $ret = $fn();
 
         // For generators the body will not be run until the first operation


### PR DESCRIPTION
Added support for [`PHPUnit 6`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md).

I just need to bump `PHPUnit 5` version to [`~5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.