### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ here is just a small usage example of the two main functions:
 ```php
 <?php
 
-use iter, iter\fn;
+use iter\fn;
+
+require 'path/to/vendor/autoload.php';
 
 /* Create a rewindable map function which can be used multiple times */
 $rewindableMap = iter\makeRewindable('iter\\map');

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A small usage example for the ``map()`` and ``range()`` functions:
 ```php
 <?php
 
-use iter, iter\fn;
+use iter\fn;
 
 require 'path/to/vendor/autoload.php';
 


### PR DESCRIPTION
Remove "use iter" as it causes "Warning: The use statement with non-compound name 'iter' has no effect".
Add missing require.