### PR TITLE
Associate

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ list the function signatures as an overview:
     Iterator reindex(callable $function, iterable $iterable)
     Iterator filter(callable $predicate, iterable $iterable)
     Iterator enumerate(iterable $iterable)
+    Iterator toPairs(iterable $iterable)
+    Iterator fromPairs(iterable $iterable)
     Iterator reductions(callable $function, iterable $iterable, mixed $startValue = null)
     Iterator zip(iterable... $iterables)
     Iterator zipKeyValue(iterable $keys, iterable $values)

--- a/src/iter.php
+++ b/src/iter.php
@@ -221,26 +221,61 @@ function filter(callable $predicate, $iterable) {
 }
 
 /**
- * Enumerates pairs of [key, value] of an iterable.
- *
- * Examples:
- *
- *      iter\enumerate(['a', 'b']);
- *      => iter([0, 'a'], [1, 'b'])
- *
- *      $values = ['a', 'b', 'c', 'd'];
- *      $filter = function($t) { return $t[0] % 2 == 0; };
- *      iter\map(iter\fn\index(1), iter\filter($filter, iter\enumerate($values)));
- *      => iter('a', 'c')
+ * Alias of toPairs
  *
  * @param array|Traversable $iterable Iterable to enumerate
  *
  * @return \Iterator
  */
 function enumerate($iterable) {
+    return toPairs($iterable);
+}
+
+/**
+ * Converts an associative iterable of key => value to an iterable of pairs [key, value]
+ *
+ * Examples:
+ *
+ *      iter\toPairs(['a', 'b']);
+ *      => iter([0, 'a'], [1, 'b'])
+ *
+ *      $values = ['a', 'b', 'c', 'd'];
+ *      $filter = function($t) { return $t[0] % 2 == 0; };
+ *      iter\fromPairs(iter\filter($filter, iter\toPairs($values)));
+ *      => iter('a', 'c')
+ *
+ * @param array|Traversable $iterable Iterable to convert to pairs
+ *
+ * @return \Iterator
+ */
+function toPairs($iterable) {
     _assertIterable($iterable, 'First argument');
     foreach ($iterable as $key => $value) {
         yield [$key, $value];
+    }
+}
+
+/**
+ * Converts an iterable of tuples [key, value] into a key => value iterable.
+ * This acts as an inverse to the toPairs function.
+ *
+ * Examples:
+ *
+ *      iter\fromPairs([['a', 1], ['b', 2]])
+ *      => iter('a' => 1, 'b' => 2)
+ *
+ *      $map = ['a' => 1, 'b' => 2];
+ *      iter\fromPairs(iter\toPairs($map))
+ *      => iter('a' => 1, 'b' => 2)
+ *
+ * @param array|Traversable $iterable Iterable to convert from pairs
+ *
+ * @return \Iterator
+ */
+function fromPairs($iterable) {
+    _assertIterable($iterable, 'First argument');
+    foreach ($iterable as list($key, $value)) {
+        yield $key => $value;
     }
 }
 

--- a/src/iter.rewindable.php
+++ b/src/iter.rewindable.php
@@ -58,6 +58,9 @@ namespace iter\rewindable {
     function flatMap()     { return new _RewindableGenerator('iter\flatMap',     func_get_args()); }
     function reindex()     { return new _RewindableGenerator('iter\reindex',     func_get_args()); }
     function filter()      { return new _RewindableGenerator('iter\filter',      func_get_args()); }
+    function enumerate()   { return new _RewindableGenerator('iter\enumerate',   func_get_args()); }
+    function toPairs()     { return new _RewindableGenerator('iter\toPairs',     func_get_args()); }
+    function fromPairs()   { return new _RewindableGenerator('iter\fromPairs',   func_get_args()); }
     function reductions()  { return new _RewindableGenerator('iter\reductions',  func_get_args()); }
     function zip()         { return new _RewindableGenerator('iter\zip',         func_get_args()); }
     function zipKeyValue() { return new _RewindableGenerator('iter\zipKeyValue', func_get_args()); }

--- a/test/IterRewindableTest.php
+++ b/test/IterRewindableTest.php
@@ -41,6 +41,18 @@ class IterRewindableTest extends \PHPUnit_Framework_TestCase {
             rewindable\filter(fn\operator('<', 0), rewindable\range(-5, 5))
         );
         $this->assertRewindableEquals(
+            [[0,0], [1,1], [2,2], [3,3], [4,4], [5,5]],
+            rewindable\enumerate(rewindable\range(0, 5))
+        );
+        $this->assertRewindableEquals(
+            [[0,0], [1,1], [2,2], [3,3], [4,4], [5,5]],
+            rewindable\toPairs(rewindable\range(0, 5))
+        );
+        $this->assertRewindableEquals(
+            [0, 1, 2, 3, 4, 5],
+            rewindable\fromPairs([[0,0], [1,1], [2,2], [3,3], [4,4], [5,5]])
+        );
+        $this->assertRewindableEquals(
             [[0,5], [1,4], [2,3], [3,2], [4,1], [5,0]],
             rewindable\zip(rewindable\range(0, 5), rewindable\range(5, 0, -1))
         );

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -98,16 +98,29 @@ class IterTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame([-5, -4, -3, -2, -1], toArray($filtered));
     }
 
-    public function testEnumerate() {
-         $this->assertSame([[0, 'a'], [1, 'b']], toArray(enumerate(['a', 'b'])));
+    public function testEnumerateIsAliasOfToPairs() {
+        $this->assertSame(toArray(toPairs(['a', 'b'])), toArray(enumerate(['a', 'b'])));
     }
 
-    public function testEnumerateWithStringKeys() {
-        $enumerated = enumerate([
+    public function testToPairs() {
+         $this->assertSame([[0, 'a'], [1, 'b']], toArray(toPairs(['a', 'b'])));
+    }
+
+    public function testToPairsWithStringKeys() {
+        $enumerated = toPairs([
             'a' => 1,
             'b' => 2,
         ]);
         $this->assertSame([['a', 1], ['b', 2]], toArray($enumerated));
+    }
+
+    public function testFromPairs() {
+        $this->assertSame(['a', 'b'], toArrayWithKeys(fromPairs([[0, 'a'], [1, 'b']])));
+    }
+
+    public function testFromPairsInverseToPairs() {
+        $map = ['a' => 1, 'b' => 2];
+        $this->assertSame($map, toArrayWithKeys(fromPairs(toPairs($map))));
     }
 
     public function testZip() {


### PR DESCRIPTION
- Added the associate function to inverse enumerate

A good example of where this would be useful is if you need to map over the keys and values at the same time:

```php
$dict = [
    'a' => 1,
    'b' => 2,
    'c' => 3,
];
iter\associate(iter\map(function($tup) {
      return [strtoupper($tup[0], $tup[1] * 2];
}, iter\enumerate($dict));
// iter('A' => 2, 'B' => 4, 'C' => 6)
```

Basically, it provides a much cleaner way to *un*-enumerate an iterable.