### PR TITLE
WIP: Initial Stab at Currying

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 
+require __DIR__ . '/iter.curried.php';
 require __DIR__ . '/iter.fn.php';
 require __DIR__ . '/iter.php';
 require __DIR__ . '/iter.rewindable.php';

--- a/src/iter.curried.php
+++ b/src/iter.curried.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace iter {
+    function curry(callable $fn, $num = 1) {
+        if ($num <= 0) {
+            return $fn;
+        }
+
+        return function($arg1) use ($fn, $num) {
+            return curry(function(...$args) use ($arg1, $fn) {
+                return $fn($arg1, ...$args);
+            }, $num - 1);
+        };
+    }
+
+    function compose(...$fns) {
+        return pipe(...array_reverse($fns));
+    }
+
+    function pipe(...$fns) {
+        return function($arg) use ($fns) {
+            return reduce(function($arg, $fn) {
+                return $fn($arg);
+            }, $fns, $arg);
+        };
+    }
+}
+
+namespace iter\curried {
+    use function iter\curry;
+
+    function map()       { return curry('iter\map')(func_get_arg(0)); }
+    function mapKeys()   { return curry('iter\mapKeys')(func_get_arg(0)); }
+    function flatMap()   { return curry('iter\flatMap')(func_get_arg(0)); }
+    function reindex()   { return curry('iter\reindex')(func_get_arg(0)); }
+    function apply()     { return curry('iter\apply')(func_get_arg(0)); }
+    function filter()    { return curry('iter\filter')(func_get_arg(0)); }
+    function take()      { return curry('iter\take')(func_get_arg(0)); }
+    function drop()      { return curry('iter\drop')(func_get_arg(0)); }
+    function any()       { return curry('iter\any')(func_get_arg(0)); }
+    function all()       { return curry('iter\all')(func_get_arg(0)); }
+    function search()    { return curry('iter\search')(func_get_arg(0)); }
+    function takeWhile() { return curry('iter\takeWhile')(func_get_arg(0)); }
+    function dropWhile() { return curry('iter\dropWhile')(func_get_arg(0)); }
+    function join()      { return curry('iter\join')(func_get_arg(0)); }
+    function recurse()   { return curry('iter\recurse')(func_get_arg(0)); }
+}

--- a/test/IterCurriedTest.php
+++ b/test/IterCurriedTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace iter;
+
+use PHPUnit\Framework\TestCase;
+
+class IterCurriedTest extends TestCase
+{
+    public function testCurry() {
+        $fn = function($a, $b, $c) {
+            return [$a, $b, $c];
+        };
+
+        $this->assertEquals(
+            [1,2,3],
+            curry($fn, 2)(1)(2)(3)
+        );
+    }
+
+    public function testPipe() {
+        $a = function($a) { return $a . 'a'; };
+        $b = function($b) { return $b . 'b'; };
+        $this->assertEquals(
+            'ab',
+            pipe($a, $b)('')
+        );
+    }
+
+    public function testCompose() {
+        $a = function($a) { return $a . 'a'; };
+        $b = function($b) { return $b . 'b'; };
+        $this->assertEquals(
+            'ba',
+            compose($a, $b)('')
+        );
+    }
+
+    private function assertCurriedEquals($array, $iter, $withKeys = false) {
+        $fn = $withKeys ? 'iter\\toArrayWithKeys' : 'iter\\toArray';
+        $this->assertSame($array, $fn($iter));
+    }
+
+    public function testCurriedVariants() {
+        $this->assertCurriedEquals(
+            [3, 6, 9, 12, 15],
+            curried\map(fn\operator('*', 3))(range(1, 5))
+        );
+        $this->assertCurriedEquals(
+            ['a' => 1, 'b' => 2, 'c' => 3],
+            curried\mapKeys('strtolower')(['A' => 1, 'B' => 2, 'C' => 3]),
+            true
+        );
+        $this->assertCurriedEquals(
+            [-1, 1, -2, 2, -3, 3, -4, 4, -5, 5],
+            curried\flatMap(function($v) {
+                return [-$v, $v];
+            })([1, 2, 3, 4, 5])
+        );
+        $this->assertCurriedEquals(
+            [2 => 1, 4 => 2, 6 => 3, 8 => 4],
+            curried\reindex(fn\operator('*', 2))([1, 2, 3, 4]),
+            true
+        );
+        $result = [];
+        curried\apply(function($v) use (&$result) {
+            $result[] = $v;
+        })([1,2,3]);
+        $this->assertCurriedEquals(
+            [1,2,3],
+            $result
+        );
+        $this->assertCurriedEquals(
+            [-5, -4, -3, -2, -1],
+            curried\filter(fn\operator('<', 0))(range(-5, 5))
+        );
+        $this->assertCurriedEquals(
+            [1,2],
+            curried\take(2)([1,2,3,4])
+        );
+        $this->assertCurriedEquals(
+            [3,4],
+            curried\drop(2)([1,2,3,4])
+        );
+        $this->assertEquals(
+            true,
+            curried\any(fn\operator('==', 2))([1,2,3])
+        );
+        $this->assertEquals(
+            false,
+            curried\all(fn\operator('>', 2))([2,3])
+        );
+        $this->assertEquals(
+            2,
+            curried\search(fn\operator('<', 3))([3,5,2])
+        );
+        $this->assertCurriedEquals(
+            [1,2],
+            curried\takeWhile(fn\operator('<=', 2))([1,2,3,4])
+        );
+        $this->assertCurriedEquals(
+            [3,4],
+            curried\dropWhile(fn\operator('<=', 2))([1,2,3,4])
+        );
+        $this->assertEquals(
+            'a,b,c',
+            curried\join(',')(['a', 'b', 'c'])
+        );
+        $this->assertCurriedEquals(
+            [1,2,[3,4]],
+            curried\recurse('iter\toArray')([1,2, new \ArrayIterator([3,4])])
+        );
+    }
+}
+


### PR DESCRIPTION
Initial stab at currying to implement something like mentioned [here](https://github.com/nikic/iter/issues/54#issuecomment-357458482).

Added a `curry` func to curry n-levels deep, and a `pipe` and `compose` functions to utilize the new curried versions.

The main issue I found is that some functions would work to be curried, but *not* with their current argument order like `chunk` or `slice`. Also default arguments kind of pose a bit of an issue with some of these functions because if we move the iterables to the last argument, then the default args are no longer default but required. We could probably get away with this by maybe making different variations of the funcs with default args.


Example: 

`slice(iterable $iterable, $start, $end = INF)`

A curried version might be: `slice($start = 0)($end = INF)($iterable)` or `slice($start = 0)($iterable)`.