### PR TITLE
Add head function

### DIFF
--- a/src/iter.php
+++ b/src/iter.php
@@ -736,6 +736,21 @@ function dropWhile(callable $predicate, iterable $iterable): \Iterator {
 }
 
 /**
+ * Takes a non-empty iterable and returns the first element.
+ *
+ * @param iterable $iterable
+ * @return mixed
+ * @throws \InvalidArgumentException if argument is empty
+ */
+function head(iterable $iterable) {
+    foreach ($iterable as $value) {
+        return $value;
+    }
+
+    throw new \InvalidArgumentException('Argument must be non-empty');
+}
+
+/**
  * Takes an iterable containing any amount of nested iterables and returns
  * a flat iterable with just the values.
  *

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -272,6 +272,21 @@ class IterTest extends TestCase {
         );
     }
 
+    public function testHead()
+    {
+        $this->assertSame(1, head([1,2,3]));
+        $this->assertSame(4, head(range(4,8)));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Argument must be non-empty
+     */
+    public function testHeadOnEmptyArgumentError()
+    {
+        head([]);
+    }
+
     public function testFlatten() {
         $this->assertSame(
             [1, 2, 3, 4, 5],


### PR DESCRIPTION
Would be nice to have a function that fetches the head of an iterable and throws an exception if it's non-empty instead of having to call the `current` function on an iterator and checking whether it's not null.