### PR TITLE
Enhancement: Reference phpunit.xsd as installed with composer

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="./src/bootstrap.php">
     <testsuites>
         <testsuite name="Iter Test Suite">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="false"
+<phpunit
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="false"
          convertErrorsToExceptions="true"


### PR DESCRIPTION
This PR

* [x] references `phpunit.xsd` as installed with `composer`
* [x] removes an invalid configuration attribute

💁‍♂️ Running

```
$ vendor/bin/phpunit
```

on current `master` yields

```
PHPUnit 7.3.1 by Sebastian Bergmann and contributors.

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 12:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.

  Test results may not be as expected.


................................................................. 65 / 97 ( 67%)
................................                                  97 / 97 (100%)

Time: 56 ms, Memory: 4.00MB

OK (97 tests, 270 assertions)
```