### PR TITLE
Enhancement: Cache dependencies between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ php:
   - 7.1
   - 7.2
 
+cache:
+  directories:
+  - $HOME/.composer/cache
+
 install:
   - composer install --prefer-dist
 


### PR DESCRIPTION
This PR

* [x] caches dependencies as installed with `composer` between Travis CI builds

💁‍♂️ For reference, see https://docs.travis-ci.com/user/caching/#arbitrary-directories.