### PR TITLE
[WIP] Implemented split #66

### DIFF
--- a/src/iter.php
+++ b/src/iter.php
@@ -899,7 +899,7 @@ function join(string $separator, iterable $iterable): string {
  * Examples:
  *
  *      iter\split(', ', 'a, b, c')
- *      => iterable with values 'a', 'b' and 'c'
+ *      => iter('a', 'b', 'c')
  *
  * @param string $separator Separator to use between elements
  * @param string $data The iterable to join

--- a/src/iter.php
+++ b/src/iter.php
@@ -914,7 +914,7 @@ function split(string $separator, string $data): iterable
 
     $offset = 0;
     while (
-        $offset < strlen($data)
+        $offset < \strlen($data)
         && false !== $nextOffset = strpos($data, $separator, $offset)
     ) {
         yield substr($data, $offset, $nextOffset - $offset);

--- a/src/iter.php
+++ b/src/iter.php
@@ -894,6 +894,45 @@ function join(string $separator, iterable $iterable): string {
 }
 
 /**
+ * Splits a string by a separator
+ *
+ * Examples:
+ *
+ *      iter\split(', ', 'a, b, c')
+ *      => iterable with values 'a', 'b' and 'c'
+ *
+ * @param string $separator Separator to use between elements
+ * @param string $data The iterable to join
+ *
+ * @return iterable
+ */
+function split(string $separator, string $data): iterable
+{
+    $separatorParts = str_split($separator, 1);
+    $separatorLength = count($separatorParts);
+    $separatorMatch = 0;
+
+    $elem = '';
+    for($i = 0, $l = strlen($data); $i < $l; $i++) {
+        if ($data[$i] === $separator[$separatorMatch]) {
+            $separatorMatch++;
+        }
+
+        $elem .= $data[$i];
+        if ($separatorMatch === $separatorLength) {
+            yield substr($elem, 0, -1 * $separatorLength);
+            $elem = '';
+            $separatorMatch = 0;
+        }
+
+    }
+
+    if (!empty($elem)) {
+        yield $elem;
+    }
+}
+
+/**
  * Returns the number of elements an iterable contains.
  *
  * This function is not recursive, it counts only the number of elements in the

--- a/src/iter.php
+++ b/src/iter.php
@@ -902,7 +902,7 @@ function join(string $separator, iterable $iterable): string {
  *      => iter('a', 'b', 'c')
  *
  * @param string $separator Separator to use between elements
- * @param string $data The iterable to join
+ * @param string $data The string to split
  *
  * @return iterable
  */

--- a/src/iter.php
+++ b/src/iter.php
@@ -912,15 +912,17 @@ function split(string $separator, string $data): iterable
         throw new \InvalidArgumentException('Separator must be non-empty string');
     }
 
-    $offset = 0;
-    while (
-        $offset < \strlen($data)
-        && false !== $nextOffset = strpos($data, $separator, $offset)
-    ) {
-        yield substr($data, $offset, $nextOffset - $offset);
-        $offset = $nextOffset + strlen($separator);
-    }
-    yield substr($data, $offset);
+    return (function() use ($separator, $data) {
+        $offset = 0;
+        while (
+            $offset < strlen($data)
+            && false !== $nextOffset = strpos($data, $separator, $offset)
+        ) {
+            yield substr($data, $offset, $nextOffset - $offset);
+            $offset = $nextOffset + strlen($separator);
+        }
+        yield substr($data, $offset);
+    })();
 }
 
 /**

--- a/src/iter.php
+++ b/src/iter.php
@@ -908,20 +908,20 @@ function join(string $separator, iterable $iterable): string {
  */
 function split(string $separator, string $data): iterable
 {
-    if (strlen($separator) === 0) {
+    if (\strlen($separator) === 0) {
         throw new \InvalidArgumentException('Separator must be non-empty string');
     }
 
     return (function() use ($separator, $data) {
         $offset = 0;
         while (
-            $offset < strlen($data)
+            $offset < \strlen($data)
             && false !== $nextOffset = strpos($data, $separator, $offset)
         ) {
-            yield substr($data, $offset, $nextOffset - $offset);
-            $offset = $nextOffset + strlen($separator);
+            yield \substr($data, $offset, $nextOffset - $offset);
+            $offset = $nextOffset + \strlen($separator);
         }
-        yield substr($data, $offset);
+        yield \substr($data, $offset);
     })();
 }
 

--- a/src/iter.php
+++ b/src/iter.php
@@ -908,6 +908,10 @@ function join(string $separator, iterable $iterable): string {
  */
 function split(string $separator, string $data): iterable
 {
+    if (strlen($separator) === 0) {
+        throw new \InvalidArgumentException('Separator must be non-empty string');
+    }
+
     $offset = 0;
     while (
         $offset < strlen($data)

--- a/src/iter.php
+++ b/src/iter.php
@@ -908,28 +908,15 @@ function join(string $separator, iterable $iterable): string {
  */
 function split(string $separator, string $data): iterable
 {
-    $separatorParts = str_split($separator, 1);
-    $separatorLength = count($separatorParts);
-    $separatorMatch = 0;
-
-    $elem = '';
-    for($i = 0, $l = strlen($data); $i < $l; $i++) {
-        if ($data[$i] === $separator[$separatorMatch]) {
-            $separatorMatch++;
-        }
-
-        $elem .= $data[$i];
-        if ($separatorMatch === $separatorLength) {
-            yield substr($elem, 0, -1 * $separatorLength);
-            $elem = '';
-            $separatorMatch = 0;
-        }
-
+    $offset = 0;
+    while (
+        $offset < strlen($data)
+        && false !== $nextOffset = strpos($data, $separator, $offset)
+    ) {
+        yield substr($data, $offset, $nextOffset - $offset);
+        $offset = $nextOffset + strlen($separator);
     }
-
-    if (!empty($elem)) {
-        yield $elem;
-    }
+    yield substr($data, $offset);
 }
 
 /**

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -443,7 +443,7 @@ class IterTest extends TestCase {
         $this->assertSame(['c', '', ''], toArray(split(',', 'c,,')));
 
         $this->expectException(\InvalidArgumentException::class);
-        toArray(split('', 'a'));
+        split('', 'a');
     }
 
     public function testChunk() {

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -437,6 +437,13 @@ class IterTest extends TestCase {
     public function testSplit() {
         $this->assertSame(['a', 'b', 'c'], toArray(split(', ', 'a, b, c')));
         $this->assertSame(['b', 'b', 'b', 'b', 'b', 'b', 'b'], toArray(split('a', 'babababababab')));
+
+        $this->assertSame(['a', 'b', '', '', 'c'], toArray(split(',', 'a,b,,,c')));
+        $this->assertSame(['', '', 'c'], toArray(split(',', ',,c')));
+        $this->assertSame(['c', '', ''], toArray(split(',', 'c,,')));
+
+        $this->expectException(\InvalidArgumentException::class);
+        toArray(split('', 'a'));
     }
 
     public function testChunk() {

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -436,7 +436,6 @@ class IterTest extends TestCase {
 
     public function testSplit() {
         $this->assertSame(['a', 'b', 'c'], toArray(split(', ', 'a, b, c')));
-
         $this->assertSame(['b', 'b', 'b', 'b', 'b', 'b', 'b'], toArray(split('a', 'babababababab')));
     }
 

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -434,6 +434,12 @@ class IterTest extends TestCase {
         );
     }
 
+    public function testSplit() {
+        $this->assertSame(['a', 'b', 'c'], toArray(split(', ', 'a, b, c')));
+
+        $this->assertSame(['b', 'b', 'b', 'b', 'b', 'b', 'b'], toArray(split('a', 'babababababab')));
+    }
+
     public function testChunk() {
         $iterable = new \ArrayIterator(
             ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5]


### PR DESCRIPTION
The implementation takes care to not use string comparison functions to prevent needless copying of data..
This does make it a little bit harder to read, so might not be worth it.

Todo:

- [ ] `splitStream`
- [ ] `splitCallable`

Please check the implementation in #66 as well, it reads a lot easier but comes with the cost of having to do a `substr` call for every character in the data instead of only when emitting a value.
