### PR TITLE
Add mapWithKeys()

### DIFF
--- a/src/iter.php
+++ b/src/iter.php
@@ -106,6 +106,35 @@ function mapKeys(callable $function, iterable $iterable): \Iterator {
 }
 
 /**
+ * Applies a mapping function to all values of an iterator, passing both the key and the value into the callback.
+ *
+ * The function is passed the current iterator value and key and should return a
+ * modified iterator value. The key is left as-is but passed to the mapping
+ * function as the second parameter.
+ *
+ * Examples:
+ *
+ *     iter\mapWithKeys(iter\func\operator('*'), range(0, 5));
+ *     => iter(0, 1, 4, 9, 16, 25)
+ *
+ *     iter\mapWithKeys(
+ *         function ($v, $k) { return sprintf('%s%s', $k, $v); },
+ *         ['foo' => 'bar', 'bing' => 'baz']
+ *     );
+ *     => iter(['foo' => 'foobar', 'bing' => 'bingbaz'])
+ *
+ * @param callable $function Mapping function: mixed function(mixed $value, mixed $key)
+ * @param iterable $iterable Iterable to be mapped over
+ *
+ * @return \Iterator
+ */
+function mapWithKeys(callable $function, iterable $iterable): \Iterator {
+    foreach ($iterable as $key => $value) {
+        yield $key => $function($value, $key);
+    }
+}
+
+/**
  *
  * Applies a function to each value in an iterator and flattens the result.
  *

--- a/src/iter.rewindable.php
+++ b/src/iter.rewindable.php
@@ -56,6 +56,7 @@ namespace iter\rewindable {
     function range()         { return new _RewindableGenerator('iter\range',         func_get_args()); }
     function map()           { return new _RewindableGenerator('iter\map',           func_get_args()); }
     function mapKeys()       { return new _RewindableGenerator('iter\mapKeys',       func_get_args()); }
+    function mapWithKeys()   { return new _RewindableGenerator('iter\mapWithKeys',   func_get_args()); }
     function flatMap()       { return new _RewindableGenerator('iter\flatMap',       func_get_args()); }
     function reindex()       { return new _RewindableGenerator('iter\reindex',       func_get_args()); }
     function filter()        { return new _RewindableGenerator('iter\filter',        func_get_args()); }

--- a/test/IterRewindableTest.php
+++ b/test/IterRewindableTest.php
@@ -27,6 +27,10 @@ class IterRewindableTest extends TestCase {
             true
         );
         $this->assertRewindableEquals(
+            [0, 1, 4, 9, 16, 25],
+            rewindable\mapWithKeys(func\operator('*'), rewindable\range(0, 5))
+        );
+        $this->assertRewindableEquals(
             [-1, 1, -2, 2, -3, 3, -4, 4, -5, 5],
             rewindable\flatMap(function($v) {
                 return [-$v, $v];

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -59,6 +59,21 @@ class IterTest extends TestCase {
         );
     }
 
+    public function testMapWithKeys()
+    {
+        $mapped = mapWithKeys(func\operator('*'), range(0, 5));
+        $this->assertSame([0, 1, 4, 9, 16, 25], toArray($mapped));
+
+        $mapped = mapWithKeys(
+            function ($v, $k) { return sprintf('%s%s', $k, $v); },
+            ['foo' => 'bar', 'bing' => 'baz']
+        );
+        $this->assertSame(
+            ['foo' => 'foobar', 'bing' => 'bingbaz'],
+            toArrayWithKeys($mapped)
+        );
+    }
+
     public function testFlatMap() {
         $this->assertSame(
             [-1, 1, -2, 2, -3, 3, -4, 4, -5, 5],


### PR DESCRIPTION
#64 caught my eye. I noticed that changing how the existing methods worked would cause issues, so I made a new `mapWithKeys()` method that passes the iterator key in addition to its value to the callback.

Here is a copy/paste of the test I wrote for it, to see it in action:
```php
$mapped = mapWithKeys(func\operator('*'), range(0, 5));
$this->assertSame([0, 1, 4, 9, 16, 25], toArray($mapped));

$mapped = mapWithKeys(
    function ($v, $k) { return sprintf('%s%s', $k, $v); },
    ['foo' => 'bar', 'bing' => 'baz']
);
$this->assertSame(
    ['foo' => 'foobar', 'bing' => 'bingbaz'],
    toArrayWithKeys($mapped)
);
```