### PR TITLE
Replace anonymous function by IteratorIterator

### DIFF
--- a/src/iter.php
+++ b/src/iter.php
@@ -1032,12 +1032,9 @@ function toIter(iterable $iterable): \Iterator {
     if ($iterable instanceof \IteratorAggregate) {
         return $iterable->getIterator();
     }
-
+    
     // Traversable, but not Iterator or IteratorAggregate
-    $generator = function() use($iterable) {
-        yield from $iterable;
-    };
-    return $generator();
+    return new \IteratorIterator($iterable);
 }
 
 /**


### PR DESCRIPTION
Hello,

Is there any reason to prefer the anonymous function than the IteratorIterator ?