### PR TITLE
.gitignore: ignore PHPUnit cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 composer.lock
+.phpunit.result.cache


### PR DESCRIPTION
Since PHPUnit 8.x, PHPUnit generates a cache file. This file should not be committed to the repository.