### PR TITLE
PHP 8.1: fix deprecation notices

### DIFF
--- a/src/iter.rewindable.php
+++ b/src/iter.rewindable.php
@@ -48,6 +48,9 @@ namespace iter {
 }
 
 namespace iter\rewindable {
+
+    use ReturnTypeWillChange;
+
     /**
      * These functions are just rewindable wrappers around the normal
      * non-rewindable functions from the iter namespace
@@ -100,26 +103,28 @@ namespace iter\rewindable {
             $this->generator = null;
         }
 
-        public function rewind() {
+        public function rewind(): void {
             $function = $this->function;
             $this->generator = $function(...$this->args);
         }
 
-        public function next() {
+        public function next(): void {
             if (!$this->generator) { $this->rewind(); }
             $this->generator->next();
         }
 
-        public function valid() {
+        public function valid(): bool {
             if (!$this->generator) { $this->rewind(); }
             return $this->generator->valid();
         }
 
+        #[ReturnTypeWillChange]
         public function key() {
             if (!$this->generator) { $this->rewind(); }
             return $this->generator->key();
         }
 
+        #[ReturnTypeWillChange]
         public function current() {
             if (!$this->generator) { $this->rewind(); }
             return $this->generator->current();

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -622,7 +622,7 @@ class IterTest extends TestCase {
 }
 
 class _CountableTestDummy implements \Countable {
-    public function count() {
+    public function count(): int {
         return 42;
     }
 }


### PR DESCRIPTION
A run on PHP 8.1 currently shows:
```
PHP Deprecated:  Return type of iter\rewindable\_RewindableGenerator::current() should either be compatible with Iterator::current(): mixed, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/iter/iter/src/iter.rewindable.php on line 123
PHP Deprecated:  Return type of iter\rewindable\_RewindableGenerator::next() should either be compatible with Iterator::next(): void, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/iter/iter/src/iter.rewindable.php on line 108
PHP Deprecated:  Return type of iter\rewindable\_RewindableGenerator::key() should either be compatible with Iterator::key(): mixed, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/iter/iter/src/iter.rewindable.php on line 118
PHP Deprecated:  Return type of iter\rewindable\_RewindableGenerator::valid() should either be compatible with Iterator::valid(): bool, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/iter/iter/src/iter.rewindable.php on line 113
PHP Deprecated:  Return type of iter\rewindable\_RewindableGenerator::rewind() should either be compatible with Iterator::rewind(): void, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/iter/iter/src/iter.rewindable.php on line 103
PHP Deprecated:  Return type of iter\_CountableTestDummy::count() should either be compatible with Countable::count(): int, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/runner/work/iter/iter/test/iterTest.php on line 625
```

These deprecation notices relate to the [Return types for internal methods RFC](https://wiki.php.net/rfc/internal_method_return_types) in PHP 8.1.

Using the attribute will silence the deprecation notices for now for those methods for which it cannot be added yet (PHP 8.0 `mixed`).
For all other methods, the return type has now been added.