### PR TITLE
Add `@return` next to `#[\ReturnTypeWillChange]`

### DIFF
--- a/src/iter.rewindable.php
+++ b/src/iter.rewindable.php
@@ -118,12 +118,18 @@ namespace iter\rewindable {
             return $this->generator->valid();
         }
 
+        /**
+         * @return mixed
+         */
         #[ReturnTypeWillChange]
         public function key() {
             if (!$this->generator) { $this->rewind(); }
             return $this->generator->key();
         }
 
+        /**
+         * @return mixed
+         */
         #[ReturnTypeWillChange]
         public function current() {
             if (!$this->generator) { $this->rewind(); }


### PR DESCRIPTION
This change allows static analysers, and developers, to know the return type without having to rely on external knowledge (i.e. a PHP internal stub library).
This helps directly when the library is used with Symfony, as it'll suppress type deprecations that will be triggered as of version 5.4.