### PR TITLE
Feature - Psalm annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           php-version: ${{ matrix.php }}
           ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
           coverage: none
-          tools: none
+          tools: composer
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,11 @@ jobs:
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: "Install Composer dependencies (PHP < 8.1)"
         if: ${{ matrix.php < '8.1' }}
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: "Install Composer dependencies (PHP 8.1)"
         if: ${{ matrix.php >= '8.1' }}
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs
 

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ $res = $rewindableMap(func\operator('*', 3), [1, 2, 3]);
 $res = iter\callRewindable('iter\\map', func\operator('*', 3), [1, 2, 3]);
 ```
 
-The above functions are only useful for your own generators though, for the
-`iter` generators rewindable variants are directly provided with an
+The above functions are only useful for your own iterators though; for the
+`iter` iterators, rewindable variants are directly provided with an
 `iter\rewindable` prefix:
 
     $res = iter\rewindable\map(func\operator('*', 3), [1, 2, 3]);

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
-        "vimeo/psalm": "^4.18 || ^5.13"
+        "vimeo/psalm": "^4.18 || ^5.13",
+        "phpstan/phpstan": "^1.4"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "php": ">=7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+        "vimeo/psalm": "^4.18 || ^5.13"
     },
     "autoload": {
         "files": [

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="4"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="true"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -6,10 +6,11 @@
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     findUnusedBaselineEntry="true"
-    findUnusedCode="true"
+    findUnusedCode="false"
 >
     <projectFiles>
         <directory name="src" />
+        <directory name="test" />
         <ignoreFiles>
             <directory name="vendor" />
         </ignoreFiles>

--- a/src/iter.func.php
+++ b/src/iter.func.php
@@ -2,6 +2,23 @@
 
 namespace iter\func;
 
+/**
+ * Returns a callable which extracts a given property from an array.
+ *
+ * Example:
+ *
+ *     $array = [ 'foo' => 42 ];
+ *
+ *     func\index('foo')($array);
+ *     => 42
+ *
+ *
+ * @param string|int $index
+ * @psalm-param array-key $index
+ *
+ * @return callable
+ * @psalm-return callable(array):mixed
+ */
 function index($index) {
     return function($array) use ($index) {
         return $array[$index];
@@ -31,9 +48,11 @@ function index($index) {
  *     $getIndexFooBarBaz($array)
  *     => 42
  *
- * @param mixed[] ...$indices Path of indices
+ * @param string|int ...$indices Path of indices
+ * @psalm-param array-key ...$indices
  *
  * @return callable
+ * @psalm-return callable(array):mixed
  */
 function nested_index(...$indices) {
     return function($array) use ($indices) {
@@ -45,18 +64,75 @@ function nested_index(...$indices) {
     };
 }
 
+/**
+ * Returns a callable which returns a given property from an object.
+ *
+ * Example:
+ *
+ *    $object = new \stdClass();
+ *    $object->foo = 42;
+ *
+ *    func\property('foo')($object);
+ *    => 42
+ *
+ * @param string $propertyName
+ *
+ * @return callable
+ * @psalm-return callable(object):mixed
+ */
 function property($propertyName) {
     return function($object) use ($propertyName) {
         return $object->$propertyName;
     };
 }
 
+/**
+ * Returns a callable which calls a method on an object, optionally with some
+ * provided arguments.
+ *
+ * Example:
+ *
+ *     class Foo {
+ *         public function bar($a, $b) {
+ *             return $a + $b;
+ *         }
+ *     }
+ *
+ *     $foo = new Foo();
+ *
+ *     func\method('bar', [1, 2])($foo);
+ *     => 3
+ *
+ * @param string $methodName
+ * @param mixed[] $args
+ *
+ * @return callable
+ * @psalm-return callable(object):mixed
+ */
 function method($methodName, $args = []) {
     return function($object) use ($methodName, $args) {
         return $object->$methodName(...$args);
     };
 }
 
+/**
+ * Returns a callable which applies the specified operator to the argument.
+ *
+ * Examples:
+ *
+ *     $addOne = func\operator('+', 1);
+ *     $addOne(41);
+ *     => 42
+ *
+ *     $modulo2 = func\operator('%', 2);
+ *     $modulo2(42);
+ *     => 0
+ *
+ * @param string $operator
+ * @param mixed $arg The right-hand argument for the operator
+ *
+ * @return callable
+ */
 function operator($operator, $arg = null) {
     $functions = [
         'instanceof' => function($a, $b) { return $a instanceof $b; },
@@ -99,6 +175,29 @@ function operator($operator, $arg = null) {
     }
 }
 
+/**
+ * Takes a callable which returns a boolean, and returns another function that
+ * returns the opposite for all values.
+ *
+ * Example:
+ *     $isEven = function($x) {
+ *         return $x % 2 === 0;
+ *     };
+ *
+ *     $isOdd = func\not($isEven);
+ *
+ *     $isEven(42);
+ *     => true
+ *
+ *     $isOdd(42);
+ *     => false
+ *
+ * @param callable $function
+ * @psalm-param callable(...mixed):bool $function
+ *
+ * @return callable
+ * @psalm-return callable(...mixed):bool
+ */
 function not($function) {
     return function(...$args) use ($function) {
         return !$function(...$args);

--- a/src/iter.func.php
+++ b/src/iter.func.php
@@ -3,7 +3,7 @@
 namespace iter\func;
 
 /**
- * Returns a callable which extracts a given property from an array.
+ * Returns a callable which extracts a given index from an array.
  *
  * Example:
  *

--- a/src/iter.func.php
+++ b/src/iter.func.php
@@ -13,11 +13,9 @@ namespace iter\func;
  *     => 42
  *
  *
- * @param string|int $index
- * @psalm-param array-key $index
+ * @param array-key $index
  *
- * @return callable
- * @psalm-return callable(array):mixed
+ * @return callable(array):mixed
  */
 function index($index) {
     return function($array) use ($index) {
@@ -48,11 +46,9 @@ function index($index) {
  *     $getIndexFooBarBaz($array)
  *     => 42
  *
- * @param string|int ...$indices Path of indices
- * @psalm-param array-key ...$indices
+ * @param array-key ...$indices Path of indices
  *
- * @return callable
- * @psalm-return callable(array):mixed
+ * @return callable(array):mixed
  */
 function nested_index(...$indices) {
     return function($array) use ($indices) {
@@ -77,8 +73,7 @@ function nested_index(...$indices) {
  *
  * @param string $propertyName
  *
- * @return callable
- * @psalm-return callable(object):mixed
+ * @return callable(object):mixed
  */
 function property($propertyName) {
     return function($object) use ($propertyName) {
@@ -106,8 +101,7 @@ function property($propertyName) {
  * @param string $methodName
  * @param mixed[] $args
  *
- * @return callable
- * @psalm-return callable(object):mixed
+ * @return callable(object):mixed
  */
 function method($methodName, $args = []) {
     return function($object) use ($methodName, $args) {
@@ -192,11 +186,9 @@ function operator($operator, $arg = null) {
  *     $isOdd(42);
  *     => false
  *
- * @param callable $function
- * @psalm-param callable(...mixed):bool $function
+ * @param callable(...mixed):bool $function
  *
- * @return callable
- * @psalm-return callable(...mixed):bool
+ * @return callable(...mixed):bool
  */
 function not($function) {
     return function(...$args) use ($function) {

--- a/src/iter.php
+++ b/src/iter.php
@@ -25,7 +25,7 @@ namespace iter;
  *
  * @throws \InvalidArgumentException if step is not valid
  *
- * @return \Iterator
+ * @return \Iterator<int|float>
  */
 function range($start, $end, $step = null): \Iterator {
     if ($start == $end) {
@@ -71,10 +71,14 @@ function range($start, $end, $step = null): \Iterator {
  *
  *     $column = map(iter\func\index('name'), $iter);
  *
- * @param callable $function Mapping function: mixed function(mixed $value)
- * @param iterable $iterable Iterable to be mapped over
+ * @template T
+ * @template U
  *
- * @return \Iterator
+ * @param callable $function Mapping function: mixed function(mixed $value)
+ * @param iterable<T> $iterable Iterable to be mapped over
+ * @psalm-param callable(T):U $function
+ *
+ * @return \Iterator<U>
  */
 function map(callable $function, iterable $iterable): \Iterator {
     foreach ($iterable as $key => $value) {
@@ -94,10 +98,15 @@ function map(callable $function, iterable $iterable): \Iterator {
  *     iter\mapKeys('strtolower', ['A' => 1, 'B' => 2, 'C' => 3, 'D' => 4]);
  *     => iter('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4)
  *
- * @param callable $function Mapping function: mixed function(mixed $key)
- * @param iterable $iterable Iterable those keys are to be mapped over
+ * @template TKey
+ * @template UKey
+ * @template Value
  *
- * @return \Iterator
+ * @param callable $function Mapping function: mixed function(mixed $key)
+ * @param iterable<TKey,Value> $iterable Iterable those keys are to be mapped over
+ * @psalm-param callable(TKey):UKey $function
+ *
+ * @return \Iterator<UKey,Value>
  */
 function mapKeys(callable $function, iterable $iterable): \Iterator {
     foreach ($iterable as $key => $value) {
@@ -123,10 +132,15 @@ function mapKeys(callable $function, iterable $iterable): \Iterator {
  *     );
  *     => iter(['foo' => 'foobar', 'bing' => 'bingbaz'])
  *
- * @param callable $function Mapping function: mixed function(mixed $value, mixed $key)
- * @param iterable $iterable Iterable to be mapped over
+ * @template TKey
+ * @template T
+ * @template U
  *
- * @return \Iterator
+ * @param callable $function Mapping function: mixed function(mixed $value, mixed $key)
+ * @param iterable<TKey,T> $iterable Iterable to be mapped over
+ * @psalm-param callable(T,TKey):U $function
+ *
+ * @return \Iterator<TKey,U>
  */
 function mapWithKeys(callable $function, iterable $iterable): \Iterator {
     foreach ($iterable as $key => $value) {
@@ -135,7 +149,6 @@ function mapWithKeys(callable $function, iterable $iterable): \Iterator {
 }
 
 /**
- *
  * Applies a function to each value in an iterator and flattens the result.
  *
  * The function is passed the current iterator value and should return an
@@ -147,10 +160,14 @@ function mapWithKeys(callable $function, iterable $iterable): \Iterator {
  *     iter\flatMap(function($v) { return [-$v, $v]; }, [1, 2, 3, 4, 5]);
  *     => iter(-1, 1, -2, 2, -3, 3, -4, 4, -5, 5)
  *
- * @param callable $function Mapping function: \Iterator function(mixed $value)
- * @param iterable $iterable Iterable to be mapped over
+ * @template T
+ * @template U
  *
- * @return \Iterator
+ * @param callable $function Mapping function: \Iterator function(mixed $value)
+ * @param iterable<T> $iterable Iterable to be mapped over
+ * @psalm-param callable(T):iterable<U> $function
+ *
+ * @return \Iterator<U>
  */
 function flatMap(callable $function, iterable $iterable): \Iterator {
     foreach ($iterable as $value) {
@@ -178,10 +195,15 @@ function flatMap(callable $function, iterable $iterable): \Iterator {
  *         24 => ['id' => 24, 'name' => 'bar']
  *     )
  *
- * @param callable $function Mapping function mixed function(mixed $value)
- * @param iterable $iterable Iterable to reindex
+ * @template TKey
+ * @template UKey
+ * @template Value
  *
- * @return \Iterator
+ * @param callable $function Mapping function mixed function(mixed $value)
+ * @param iterable<TKey,Value> $iterable Iterable to reindex
+ * @psalm-param callable(Value):UKey $function
+ *
+ * @return \Iterator<UKey,Value>
  */
 function reindex(callable $function, iterable $iterable): \Iterator {
     foreach ($iterable as $value) {
@@ -201,8 +223,11 @@ function reindex(callable $function, iterable $iterable): \Iterator {
  *
  *     iter\apply(iter\func\method('rewind'), $iterators);
  *
+ * @template T
+ *
  * @param callable $function Apply function: void function(mixed $value)
- * @param iterable $iterable Iterator to apply on
+ * @param iterable<T> $iterable Iterator to apply on
+ * @psalm-param callable(T):void $function
  */
 function apply(callable $function, iterable $iterable): void {
     foreach ($iterable as $value) {
@@ -224,10 +249,13 @@ function apply(callable $function, iterable $iterable): void {
  *
  *     iter\filter(iter\func\operator('instanceof', 'SomeClass'), $objects);
  *
- * @param callable $predicate Predicate: bool function(mixed $value)
- * @param iterable $iterable Iterable to filter
+ * @template T
  *
- * @return \Iterator
+ * @param callable $predicate Predicate: bool function(mixed $value)
+ * @param iterable<T> $iterable Iterable to filter
+ * @psalm-param callable(T):bool $predicate
+ *
+ * @return \Iterator<T>
  */
 function filter(callable $predicate, iterable $iterable): \Iterator {
     foreach ($iterable as $key => $value) {
@@ -240,9 +268,13 @@ function filter(callable $predicate, iterable $iterable): \Iterator {
 /**
  * Alias of toPairs().
  *
- * @param iterable $iterable Iterable to enumerate
+ * @template TKey
+ * @template TValue
  *
- * @return \Iterator
+ * @param iterable<TKey,TValue> $iterable Iterable to enumerate
+ *
+ * @return \Iterator<array>
+ * @psalm-return \Iterator<array{0:TKey, 1:TValue}>
  */
 function enumerate(iterable $iterable): \Iterator {
     return toPairs($iterable);
@@ -261,9 +293,13 @@ function enumerate(iterable $iterable): \Iterator {
  *      iter\fromPairs(iter\filter($filter, iter\toPairs($values)));
  *      => iter('a', 'c')
  *
- * @param iterable $iterable Iterable to convert to pairs
+ * @template TKey
+ * @template TValue
  *
- * @return \Iterator
+ * @param iterable<TKey,TValue> $iterable Iterable to convert to pairs
+ *
+ * @return \Iterator<array>
+ * @psalm-return \Iterator<array{0:TKey, 1:TValue}>
  */
 function toPairs(iterable $iterable): \Iterator {
     foreach ($iterable as $key => $value) {
@@ -285,9 +321,13 @@ function toPairs(iterable $iterable): \Iterator {
  *      iter\fromPairs(iter\toPairs($map))
  *      => iter('a' => 1, 'b' => 2)
  *
- * @param iterable $iterable Iterable of [key, value] pairs
+ * @template TKey
+ * @template TValue
  *
- * @return \Iterator
+ * @param iterable<array> $iterable Iterable of [key, value] pairs
+ * @psalm-param iterable<array{0:TKey, 1:TValue}> $iterable
+ *
+ * @return \Iterator<TKey,TValue>
  */
 function fromPairs(iterable $iterable): \Iterator {
     foreach ($iterable as [$key, $value]) {
@@ -309,13 +349,18 @@ function fromPairs(iterable $iterable): \Iterator {
  *      iter\reduce(iter\func\operator('*'), range(1, 5), 1)
  *      => 120
  *
+ * @template TKey
+ * @template TValue
+ * @template TAcc
+ *
  * @param callable $function Reduction function:
  *                           mixed function(mixed $acc, mixed $value, mixed $key)
- * @param iterable $iterable Iterable to reduce
- * @param mixed $startValue Start value for accumulator.
+ * @param iterable<TKey,TValue> $iterable Iterable to reduce
+ * @param TAcc $startValue Start value for accumulator.
  *                          Usually identity value of $function.
+ * @psalm-param callable(TAcc,TValue,TKey):TAcc $function
  *
- * @return mixed Result of the reduction
+ * @return TAcc Result of the reduction
  */
 function reduce(callable $function, iterable $iterable, $startValue = null) {
     $acc = $startValue;
@@ -341,13 +386,18 @@ function reduce(callable $function, iterable $iterable, $startValue = null) {
  *      iter\reductions(iter\func\operator('*'), range(1, 5), 1)
  *      => iter(1, 2, 6, 24, 120)
  *
+ * @template TKey
+ * @template TValue
+ * @template TAcc
+ *
  * @param callable $function Reduction function:
  *                           mixed function(mixed $acc, mixed $value, mixed $key)
- * @param iterable $iterable Iterable to reduce
- * @param mixed $startValue Start value for accumulator.
+ * @param iterable<TKey,TValue> $iterable Iterable to reduce
+ * @param TAcc $startValue Start value for accumulator.
  *                          Usually identity value of $function.
+ * @psalm-param callable(TAcc,TValue,TKey):TAcc $function
  *
- * @return \Iterator Intermediate results of the reduction
+ * @return \Iterator<TAcc> Intermediate results of the reduction
  */
 function reductions(callable $function, iterable $iterable, $startValue = null): \Iterator {
     $acc = $startValue;
@@ -371,7 +421,7 @@ function reductions(callable $function, iterable $iterable, $startValue = null):
  *
  * @param iterable[] ...$iterables Iterables to zip
  *
- * @return \Iterator
+ * @return \Iterator<array>
  */
 function zip(iterable ...$iterables): \Iterator {
     if (\count($iterables) === 0) {
@@ -397,10 +447,13 @@ function zip(iterable ...$iterables): \Iterator {
  *     iter\zipKeyValue(['a', 'b', 'c'], [1, 2, 3])
  *     => iter('a' => 1, 'b' => 2, 'c' => 3)
  *
- * @param iterable $keys Iterable of keys
- * @param iterable $values Iterable of values
+ * @template TKey
+ * @template TValue
  *
- * @return \Iterator
+ * @param iterable<TKey> $keys Iterable of keys
+ * @param iterable<TValue> $values Iterable of values
+ *
+ * @return \Iterator<TKey,TValue>
  */
 function zipKeyValue(iterable $keys, iterable $values): \Iterator {
     $keys = toIter($keys);
@@ -426,9 +479,11 @@ function zipKeyValue(iterable $keys, iterable $values): \Iterator {
  *     iter\chain(iter\range(0, 5), iter\range(6, 10), iter\range(11, 15))
  *     => iter(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
  *
- * @param iterable[] ...$iterables Iterables to chain
+ * @template T
  *
- * @return \Iterator
+ * @param iterable<T> ...$iterables Iterables to chain
+ *
+ * @return \Iterator<T>
  */
 function chain(iterable ...$iterables): \Iterator {
     foreach ($iterables as $iterable) {
@@ -451,10 +506,9 @@ function chain(iterable ...$iterables): \Iterator {
  *
  * @param iterable[] ...$iterables Iterables to combine
  *
- * @return \Iterator
+ * @return \Iterator<array>
  */
 function product(iterable ...$iterables): \Iterator {
-    /** @var \Iterator[] $iterators */
     $iterators = array_map('iter\\toIter', $iterables);
     $numIterators = \count($iterators);
     if (!$numIterators) {
@@ -499,14 +553,16 @@ function product(iterable ...$iterables): \Iterator {
  *      iter\slice([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5], 5, 3)
  *      => iter(0, 1, 2, 3)
  *
- * @param iterable $iterable Iterable to take the slice from
+ * @template T
+ *
+ * @param iterable<T> $iterable Iterable to take the slice from
  * @param int $start Start offset
  * @param int $length Length (if not specified all remaining values from the
  *                    iterable are used)
  *
- * @return \Iterator
+ * @return \Iterator<T>
  */
-function slice(iterable $iterable, int $start, $length = INF): \Iterator {
+function slice(iterable $iterable, int $start, $length = PHP_INT_MAX): \Iterator {
     if ($start < 0) {
         throw new \InvalidArgumentException('Start offset must be non-negative');
     }
@@ -537,10 +593,12 @@ function slice(iterable $iterable, int $start, $length = INF): \Iterator {
  *      iter\take(3, [1, 2, 3, 4, 5])
  *      => iter(1, 2, 3)
  *
- * @param int $num Number of elements to take from the start
- * @param iterable $iterable Iterable to take the elements from
+ * @template T
  *
- * @return \Iterator
+ * @param int $num Number of elements to take from the start
+ * @param iterable<T> $iterable Iterable to take the elements from
+ *
+ * @return \Iterator<T>
  */
 function take(int $num, iterable $iterable): \Iterator {
     return slice($iterable, 0, $num);
@@ -554,10 +612,12 @@ function take(int $num, iterable $iterable): \Iterator {
  *      iter\drop(3, [1, 2, 3, 4, 5])
  *      => iter(4, 5)
  *
- * @param int $num Number of elements to drop from the start
- * @param iterable $iterable Iterable to drop the elements from
+ * @template T
  *
- * @return \Iterator
+ * @param int $num Number of elements to drop from the start
+ * @param iterable<T> $iterable Iterable to drop the elements from
+ *
+ * @return \Iterator<T>
  */
 function drop(int $num, iterable $iterable): \Iterator {
     return slice($iterable, $num);
@@ -574,14 +634,17 @@ function drop(int $num, iterable $iterable): \Iterator {
  *     iter\repeat(1)
  *     => iter(1, 1, 1, 1, 1, 1, 1, 1, 1, ...)
  *
+ * @template T
+ *
  * @param mixed $value Value to repeat
- * @param int   $num   Number of repetitions (defaults to INF)
+ * @param int   $num   Number of repetitions (defaults to PHP_INT_MAX)
+ * @psalm-param T $value
  *
  * @throws \InvalidArgumentException if num is negative
  *
- * @return \Iterator
+ * @return \Iterator<T>
  */
-function repeat($value, $num = INF): \Iterator {
+function repeat($value, $num = PHP_INT_MAX): \Iterator {
     if ($num < 0) {
         throw new \InvalidArgumentException(
             'Number of repetitions must be non-negative');
@@ -600,9 +663,12 @@ function repeat($value, $num = INF): \Iterator {
  *      iter\keys(['a' => 0, 'b' => 1, 'c' => 2])
  *      => iter('a', 'b', 'c')
  *
- * @param iterable $iterable Iterable to get keys from
+ * @template TKey
+ * @template TValue
  *
- * @return \Iterator
+ * @param iterable<TKey,TValue> $iterable Iterable to get keys from
+ *
+ * @return \Iterator<TKey>
  */
 function keys(iterable $iterable): \Iterator {
     foreach ($iterable as $key => $_) {
@@ -618,9 +684,11 @@ function keys(iterable $iterable): \Iterator {
  *      iter\values([17 => 1, 42 => 2, -2 => 100])
  *      => iter(0 => 1, 1 => 42, 2 => 100)
  *
- * @param iterable $iterable Iterable to get values from
+ * @template T
  *
- * @return \Iterator
+ * @param iterable<T> $iterable Iterable to get values from
+ *
+ * @return \Iterator<T>
  */
 function values(iterable $iterable): \Iterator {
     foreach ($iterable as $value) {
@@ -642,8 +710,11 @@ function values(iterable $iterable): \Iterator {
  *      iter\all(iter\func\operator('>', 0), range(-5, 5))
  *      => false
  *
+ * @template T
+ *
  * @param callable $predicate Predicate: bool function(mixed $value)
- * @param iterable $iterable Iterable to check against the predicate
+ * @param iterable<T> $iterable Iterable to check against the predicate
+ * @psalm-param callable(T):bool $predicate
  *
  * @return bool Whether the predicate matches any value
  */
@@ -670,8 +741,11 @@ function any(callable $predicate, iterable $iterable): bool {
  *      iter\all(iter\func\operator('>', 0), range(-5, 5))
  *      => false
  *
+ * @template T
+ *
  * @param callable $predicate Predicate: bool function(mixed $value)
- * @param iterable $iterable Iterable to check against the predicate
+ * @param iterable<T> $iterable Iterable to check against the predicate
+ * @psalm-param callable(T):bool $predicate
  *
  * @return bool Whether the predicate holds for all values
  */
@@ -697,10 +771,14 @@ function all(callable $predicate, iterable $iterable): bool {
  *      iter\search(iter\func\operator('===', 'qux'), ['foo', 'bar', 'baz'])
  *      => null
  *
+ * @template T
+ *
  * @param callable $predicate Predicate: bool function(mixed $value)
- * @param iterable $iterable The iterable to search
+ * @param iterable<T> $iterable The iterable to search
+ * @psalm-param callable(T):bool $predicate
  *
  * @return null|mixed
+ * @psalm-return T|null
  */
 function search(callable $predicate, iterable $iterable) {
     foreach ($iterable as $value) {
@@ -723,10 +801,13 @@ function search(callable $predicate, iterable $iterable) {
  *      iter\takeWhile(iter\func\operator('>', 0), [3, 1, 4, -1, 5])
  *      => iter(3, 1, 4)
  *
- * @param callable $predicate Predicate: bool function(mixed $value)
- * @param iterable $iterable Iterable to take values from
+ * @template T
  *
- * @return \Iterator
+ * @param callable $predicate Predicate: bool function(mixed $value)
+ * @param iterable<T> $iterable Iterable to take values from
+ * @psalm-param callable(T):bool $predicate
+ *
+ * @return \Iterator<T>
  */
 function takeWhile(callable $predicate, iterable $iterable): \Iterator {
     foreach ($iterable as $key => $value) {
@@ -749,10 +830,13 @@ function takeWhile(callable $predicate, iterable $iterable): \Iterator {
  *      iter\dropWhile(iter\func\operator('>', 0), [3, 1, 4, -1, 5])
  *      => iter(-1, 5)
  *
- * @param callable $predicate Predicate: bool function(mixed $value)
- * @param iterable $iterable Iterable to drop values from
+ * @template T
  *
- * @return \Iterator
+ * @param callable $predicate Predicate: bool function(mixed $value)
+ * @param iterable<T> $iterable Iterable to drop values from
+ * @psalm-param callable(T):bool $predicate
+ *
+ * @return \Iterator<T>
  */
 function dropWhile(callable $predicate, iterable $iterable): \Iterator {
     $failed = false;
@@ -784,8 +868,14 @@ function dropWhile(callable $predicate, iterable $iterable): \Iterator {
  * @param int $levels Number of levels to flatten
  *
  * @return \Iterator
+ *
+ * Note: Psalm does not support recursive type definitions yet, so it is not
+ *       currently possible to correctly provide generic type information for
+ *       this function.
+ * @see https://github.com/vimeo/psalm/issues/2777
+ * @see https://github.com/vimeo/psalm/issues/5739
  */
-function flatten(iterable $iterable, $levels = INF): \Iterator {
+function flatten(iterable $iterable, int $levels = PHP_INT_MAX): \Iterator {
     if ($levels < 0) {
         throw new \InvalidArgumentException(
             'Number of levels must be non-negative'
@@ -824,9 +914,12 @@ function flatten(iterable $iterable, $levels = INF): \Iterator {
  *      iter\flip(['a' => 1, 'b' => 2, 'c' => 3])
  *      => iter(1 => 'a', 2 => 'b', 3 => 'c')
  *
- * @param iterable $iterable The iterable to flip
+ * @template TKey
+ * @template TValue
  *
- * @return \Iterator
+ * @param iterable<TKey,TValue> $iterable The iterable to flip
+ *
+ * @return \Iterator<TValue,TKey>
  */
 function flip(iterable $iterable): \Iterator {
     foreach ($iterable as $key => $value) {
@@ -845,11 +938,16 @@ function flip(iterable $iterable): \Iterator {
  *      iter\chunk([1, 2, 3, 4, 5], 2)
  *      => iter([1, 2], [3, 4], [5])
  *
- * @param iterable $iterable The iterable to chunk
- * @param int $size The size of each chunk
- * @param bool $preserveKeys Whether to preserve keys from the input iterable
+ * @template TKey
+ * @template TValue
+ * @template TPreserve of bool
  *
- * @return \Iterator An iterator of arrays
+ * @param iterable<TKey,TValue> $iterable The iterable to chunk
+ * @param int $size The size of each chunk
+ * @param TPreserve $preserveKeys Whether to preserve keys from the input iterable
+ *
+ * @return \Iterator<array> An iterator of arrays
+ * @psalm-return (TPreserve is true ? \Iterator<array<TKey,TValue>> : \Iterator<array<array-key,TValue>>)
  */
 function chunk(iterable $iterable, int $size, bool $preserveKeys = false): \Iterator {
     if ($size <= 0) {
@@ -886,10 +984,13 @@ function chunk(iterable $iterable, int $size, bool $preserveKeys = false): \Iter
  *     iter\chunkWithKeys(['a' => 1, 'b' => 2, 'c' => 3], 2)
  *     => iter(['a' => 1, 'b' => 2], ['c' => 3])
  *
- * @param iterable $iterable The iterable to chunk
+ * @template TKey
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $iterable The iterable to chunk
  * @param int $size The size of each chunk
  *
- * @return \Iterator An iterator of arrays
+ * @return \Iterator<array<TKey,TValue>> An iterator of arrays
  */
 function chunkWithKeys(iterable $iterable, int $size): \Iterator {
     return chunk($iterable, $size, true);
@@ -904,7 +1005,7 @@ function chunkWithKeys(iterable $iterable, int $size): \Iterator {
  *      => "a, b, c"
  *
  * @param string $separator Separator to use between elements
- * @param iterable $iterable The iterable to join
+ * @param iterable<string|\Stringable> $iterable The iterable to join
  *
  * @return string
  */
@@ -933,7 +1034,7 @@ function join(string $separator, iterable $iterable): string {
  * @param string $separator Separator to use between elements
  * @param string $data The string to split
  *
- * @return iterable
+ * @return iterable<string>
  */
 function split(string $separator, string $data): iterable
 {
@@ -1044,6 +1145,12 @@ function isEmpty($iterable): bool {
  * @param callable $function
  * @param iterable $iterable
  * @return mixed
+ *
+ * Note: Psalm does not support recursive type definitions yet, so it is not
+ *       currently possible to correctly provide generic type information for
+ *       this function.
+ * @see https://github.com/vimeo/psalm/issues/2777
+ * @see https://github.com/vimeo/psalm/issues/5739
  */
 function recurse(callable $function, iterable $iterable) {
     return $function(map(function($value) use($function) {
@@ -1059,9 +1166,12 @@ function recurse(callable $function, iterable $iterable) {
  *      iter\toIter([1, 2, 3])
  *      => iter(1, 2, 3)
  *
- * @param iterable $iterable The iterable to turn into an iterator
+ * @template TKey
+ * @template TValue
  *
- * @return \Iterator
+ * @param iterable<TKey,TValue> $iterable The iterable to turn into an iterator
+ *
+ * @return \Iterator<TKey,TValue>
  */
 function toIter(iterable $iterable): \Iterator {
     if (\is_array($iterable)) {
@@ -1096,9 +1206,11 @@ function toIter(iterable $iterable): \Iterator {
  *      iter\toArray(iter\chain(['a' => 1, 'b' => 2], ['a' => 3]))
  *      => [1, 2, 3]
  *
- * @param iterable $iterable The iterable to convert to an array
+ * @template T
  *
- * @return array
+ * @param iterable<T> $iterable The iterable to convert to an array
+ *
+ * @return array<T>
  */
 function toArray(iterable $iterable): array {
     $array = [];
@@ -1123,9 +1235,12 @@ function toArray(iterable $iterable): array {
  *      iter\toArrayWithKeys(iter\chain(['a' => 1, 'b' => 2], ['a' => 3]))
  *      => ['a' => 3, 'b' => 2]
  *
- * @param iterable $iterable The iterable to convert to an array
+ * @template TKey
+ * @template TValue
  *
- * @return array
+ * @param iterable<TKey,TValue> $iterable The iterable to convert to an array
+ *
+ * @return array<TKey,TValue>
  */
 function toArrayWithKeys(iterable $iterable): array {
     $array = [];

--- a/src/iter.php
+++ b/src/iter.php
@@ -74,7 +74,7 @@ function range($start, $end, $step = null): \Iterator {
  * @template T
  * @template U
  *
- * @param callable(T):U $function Mapping function: mixed function(mixed $value)
+ * @param callable(T):U $function Mapping function
  * @param iterable<T> $iterable Iterable to be mapped over
  *
  * @return \Iterator<U>
@@ -101,7 +101,7 @@ function map(callable $function, iterable $iterable): \Iterator {
  * @template UKey
  * @template Value
  *
- * @param callable(TKey):UKey $function Mapping function: mixed function(mixed $key)
+ * @param callable(TKey):UKey $function Mapping function
  * @param iterable<TKey,Value> $iterable Iterable those keys are to be mapped over
  *
  * @return \Iterator<UKey,Value>
@@ -134,7 +134,7 @@ function mapKeys(callable $function, iterable $iterable): \Iterator {
  * @template T
  * @template U
  *
- * @param callable(T,TKey):U $function Mapping function: mixed function(mixed $value, mixed $key)
+ * @param callable(T,TKey):U $function Mapping function
  * @param iterable<TKey,T> $iterable Iterable to be mapped over
  *
  * @return \Iterator<TKey,U>
@@ -160,7 +160,7 @@ function mapWithKeys(callable $function, iterable $iterable): \Iterator {
  * @template T
  * @template U
  *
- * @param callable(T):iterable<U> $function Mapping function: \Iterator function(mixed $value)
+ * @param callable(T):iterable<U> $function Mapping function
  * @param iterable<T> $iterable Iterable to be mapped over
  *
  * @return \Iterator<U>
@@ -195,7 +195,7 @@ function flatMap(callable $function, iterable $iterable): \Iterator {
  * @template UKey
  * @template Value
  *
- * @param callable(Value):UKey $function Mapping function mixed function(mixed $value)
+ * @param callable(Value):UKey $function Mapping function
  * @param iterable<TKey,Value> $iterable Iterable to reindex
  *
  * @return \Iterator<UKey,Value>
@@ -220,7 +220,7 @@ function reindex(callable $function, iterable $iterable): \Iterator {
  *
  * @template T
  *
- * @param callable(T):void $function Apply function: void function(mixed $value)
+ * @param callable(T):void $function Apply function
  * @param iterable<T> $iterable Iterator to apply on
  */
 function apply(callable $function, iterable $iterable): void {
@@ -245,7 +245,7 @@ function apply(callable $function, iterable $iterable): void {
  *
  * @template T
  *
- * @param callable(T):bool $predicate Predicate: bool function(mixed $value)
+ * @param callable(T):bool $predicate Predicate function
  * @param iterable<T> $iterable Iterable to filter
  *
  * @return \Iterator<T>
@@ -343,8 +343,7 @@ function fromPairs(iterable $iterable): \Iterator {
  * @template TValue
  * @template TAcc
  *
- * @param callable(TAcc,TValue,TKey):TAcc $function Reduction function:
- *                                                  mixed function(mixed $acc, mixed $value, mixed $key)
+ * @param callable(TAcc,TValue,TKey):TAcc $function Reduction function
  * @param iterable<TKey,TValue> $iterable Iterable to reduce
  * @param TAcc $startValue Start value for accumulator.
  *                         Usually identity value of $function.
@@ -379,11 +378,10 @@ function reduce(callable $function, iterable $iterable, $startValue = null) {
  * @template TValue
  * @template TAcc
  *
- * @param callable(TAcc,TValue,TKey):TAcc $function Reduction function:
- *                           mixed function(mixed $acc, mixed $value, mixed $key)
+ * @param callable(TAcc,TValue,TKey):TAcc $function Reduction function
  * @param iterable<TKey,TValue> $iterable Iterable to reduce
  * @param TAcc $startValue Start value for accumulator.
- *                          Usually identity value of $function.
+ *                         Usually identity value of $function.
  *
  * @return \Iterator<TAcc> Intermediate results of the reduction
  */
@@ -699,7 +697,7 @@ function values(iterable $iterable): \Iterator {
  *
  * @template T
  *
- * @param callable(T):bool $predicate Predicate: bool function(mixed $value)
+ * @param callable(T):bool $predicate Predicate function
  * @param iterable<T> $iterable Iterable to check against the predicate
  *
  * @return bool Whether the predicate matches any value
@@ -729,7 +727,7 @@ function any(callable $predicate, iterable $iterable): bool {
  *
  * @template T
  *
- * @param callable(T):bool $predicate Predicate: bool function(mixed $value)
+ * @param callable(T):bool $predicate Predicate function
  * @param iterable<T> $iterable Iterable to check against the predicate
  *
  * @return bool Whether the predicate holds for all values
@@ -758,7 +756,7 @@ function all(callable $predicate, iterable $iterable): bool {
  *
  * @template T
  *
- * @param callable(T):bool $predicate Predicate: bool function(mixed $value)
+ * @param callable(T):bool $predicate Predicate function
  * @param iterable<T> $iterable The iterable to search
  *
  * @return T|null
@@ -786,7 +784,7 @@ function search(callable $predicate, iterable $iterable) {
  *
  * @template T
  *
- * @param callable(T):bool $predicate Predicate: bool function(mixed $value)
+ * @param callable(T):bool $predicate Predicate function
  * @param iterable<T> $iterable Iterable to take values from
  *
  * @return \Iterator<T>
@@ -814,7 +812,7 @@ function takeWhile(callable $predicate, iterable $iterable): \Iterator {
  *
  * @template T
  *
- * @param callable(T):bool $predicate Predicate: bool function(mixed $value)
+ * @param callable(T):bool $predicate Predicate function
  * @param iterable<T> $iterable Iterable to drop values from
  *
  * @return \Iterator<T>

--- a/src/iter.php
+++ b/src/iter.php
@@ -997,6 +997,10 @@ function count($iterable): int {
  * Calling isEmpty() does not drain iterators, as only the valid() method will
  * be called.
  *
+ * @throws \InvalidArgumentException if the argument is not iterable or not
+ *                                   Countable, or is a recursively defined
+ *                                   \IteratorAggregate
+ *
  * @param iterable|\Countable $iterable
  * @return bool
  */
@@ -1008,7 +1012,16 @@ function isEmpty($iterable): bool {
     if ($iterable instanceof \Iterator) {
         return !$iterable->valid();
     } else if ($iterable instanceof \IteratorAggregate) {
-        return !$iterable->getIterator()->valid();
+        $inner = $iterable->getIterator();
+
+        if ($inner instanceof \Iterator) {
+            return !$inner->valid();
+        } else if ($inner !== $iterable) {
+            return isEmpty($inner);
+        } else {
+            throw new \InvalidArgumentException(
+                'Argument must not be recursively defined');
+        }
     } else {
         throw new \InvalidArgumentException(
             'Argument must be iterable or implement Countable');

--- a/src/iter.php
+++ b/src/iter.php
@@ -25,9 +25,9 @@ namespace iter;
  *
  * @throws \InvalidArgumentException if step is not valid
  *
- * @return \Generator<int|float>
+ * @return \Iterator<int|float>
  */
-function range($start, $end, $step = null): \Generator {
+function range($start, $end, $step = null): \Iterator {
     if ($start == $end) {
         yield $start;
     } elseif ($start < $end) {
@@ -77,9 +77,9 @@ function range($start, $end, $step = null): \Generator {
  * @param callable(T):U $function Mapping function: mixed function(mixed $value)
  * @param iterable<T> $iterable Iterable to be mapped over
  *
- * @return \Generator<U>
+ * @return \Iterator<U>
  */
-function map(callable $function, iterable $iterable): \Generator {
+function map(callable $function, iterable $iterable): \Iterator {
     foreach ($iterable as $key => $value) {
         yield $key => $function($value);
     }
@@ -104,9 +104,9 @@ function map(callable $function, iterable $iterable): \Generator {
  * @param callable(TKey):UKey $function Mapping function: mixed function(mixed $key)
  * @param iterable<TKey,Value> $iterable Iterable those keys are to be mapped over
  *
- * @return \Generator<UKey,Value>
+ * @return \Iterator<UKey,Value>
  */
-function mapKeys(callable $function, iterable $iterable): \Generator {
+function mapKeys(callable $function, iterable $iterable): \Iterator {
     foreach ($iterable as $key => $value) {
         yield $function($key) => $value;
     }
@@ -137,9 +137,9 @@ function mapKeys(callable $function, iterable $iterable): \Generator {
  * @param callable(T,TKey):U $function Mapping function: mixed function(mixed $value, mixed $key)
  * @param iterable<TKey,T> $iterable Iterable to be mapped over
  *
- * @return \Generator<TKey,U>
+ * @return \Iterator<TKey,U>
  */
-function mapWithKeys(callable $function, iterable $iterable): \Generator {
+function mapWithKeys(callable $function, iterable $iterable): \Iterator {
     foreach ($iterable as $key => $value) {
         yield $key => $function($value, $key);
     }
@@ -160,12 +160,12 @@ function mapWithKeys(callable $function, iterable $iterable): \Generator {
  * @template T
  * @template U
  *
- * @param callable(T):iterable<U> $function Mapping function: \Generator function(mixed $value)
+ * @param callable(T):iterable<U> $function Mapping function: \Iterator function(mixed $value)
  * @param iterable<T> $iterable Iterable to be mapped over
  *
- * @return \Generator<U>
+ * @return \Iterator<U>
  */
-function flatMap(callable $function, iterable $iterable): \Generator {
+function flatMap(callable $function, iterable $iterable): \Iterator {
     foreach ($iterable as $value) {
         yield from $function($value);
     }
@@ -198,9 +198,9 @@ function flatMap(callable $function, iterable $iterable): \Generator {
  * @param callable(Value):UKey $function Mapping function mixed function(mixed $value)
  * @param iterable<TKey,Value> $iterable Iterable to reindex
  *
- * @return \Generator<UKey,Value>
+ * @return \Iterator<UKey,Value>
  */
-function reindex(callable $function, iterable $iterable): \Generator {
+function reindex(callable $function, iterable $iterable): \Iterator {
     foreach ($iterable as $value) {
         yield $function($value) => $value;
     }
@@ -248,9 +248,9 @@ function apply(callable $function, iterable $iterable): void {
  * @param callable(T):bool $predicate Predicate: bool function(mixed $value)
  * @param iterable<T> $iterable Iterable to filter
  *
- * @return \Generator<T>
+ * @return \Iterator<T>
  */
-function filter(callable $predicate, iterable $iterable): \Generator {
+function filter(callable $predicate, iterable $iterable): \Iterator {
     foreach ($iterable as $key => $value) {
         if ($predicate($value)) {
             yield $key => $value;
@@ -266,9 +266,9 @@ function filter(callable $predicate, iterable $iterable): \Generator {
  *
  * @param iterable<TKey,TValue> $iterable Iterable to enumerate
  *
- * @return \Generator<array{0:TKey, 1:TValue}>
+ * @return \Iterator<array{0:TKey, 1:TValue}>
  */
-function enumerate(iterable $iterable): \Generator {
+function enumerate(iterable $iterable): \Iterator {
     return toPairs($iterable);
 }
 
@@ -290,9 +290,9 @@ function enumerate(iterable $iterable): \Generator {
  *
  * @param iterable<TKey,TValue> $iterable Iterable to convert to pairs
  *
- * @return \Generator<array{0:TKey, 1:TValue}>
+ * @return \Iterator<array{0:TKey, 1:TValue}>
  */
-function toPairs(iterable $iterable): \Generator {
+function toPairs(iterable $iterable): \Iterator {
     foreach ($iterable as $key => $value) {
         yield [$key, $value];
     }
@@ -317,9 +317,9 @@ function toPairs(iterable $iterable): \Generator {
  *
  * @param iterable<array{0:TKey, 1:TValue}> $iterable Iterable of [key, value] pairs
  *
- * @return \Generator<TKey,TValue>
+ * @return \Iterator<TKey,TValue>
  */
-function fromPairs(iterable $iterable): \Generator {
+function fromPairs(iterable $iterable): \Iterator {
     foreach ($iterable as [$key, $value]) {
         yield $key => $value;
     }
@@ -385,9 +385,9 @@ function reduce(callable $function, iterable $iterable, $startValue = null) {
  * @param TAcc $startValue Start value for accumulator.
  *                          Usually identity value of $function.
  *
- * @return \Generator<TAcc> Intermediate results of the reduction
+ * @return \Iterator<TAcc> Intermediate results of the reduction
  */
-function reductions(callable $function, iterable $iterable, $startValue = null): \Generator {
+function reductions(callable $function, iterable $iterable, $startValue = null): \Iterator {
     $acc = $startValue;
     foreach ($iterable as $key => $value) {
         $acc = $function($acc, $value, $key);
@@ -409,9 +409,9 @@ function reductions(callable $function, iterable $iterable, $startValue = null):
  *
  * @param iterable ...$iterables Iterables to zip
  *
- * @return \Generator<array>
+ * @return \Iterator<array>
  */
-function zip(iterable ...$iterables): \Generator {
+function zip(iterable ...$iterables): \Iterator {
     if (\count($iterables) === 0) {
         return;
     }
@@ -441,9 +441,9 @@ function zip(iterable ...$iterables): \Generator {
  * @param iterable<TKey> $keys Iterable of keys
  * @param iterable<TValue> $values Iterable of values
  *
- * @return \Generator<TKey,TValue>
+ * @return \Iterator<TKey,TValue>
  */
-function zipKeyValue(iterable $keys, iterable $values): \Generator {
+function zipKeyValue(iterable $keys, iterable $values): \Iterator {
     $keys = toIter($keys);
     $values = toIter($values);
 
@@ -471,9 +471,9 @@ function zipKeyValue(iterable $keys, iterable $values): \Generator {
  *
  * @param iterable<T> ...$iterables Iterables to chain
  *
- * @return \Generator<T>
+ * @return \Iterator<T>
  */
-function chain(iterable ...$iterables): \Generator {
+function chain(iterable ...$iterables): \Iterator {
     foreach ($iterables as $iterable) {
         yield from $iterable;
     }
@@ -494,9 +494,9 @@ function chain(iterable ...$iterables): \Generator {
  *
  * @param iterable ...$iterables Iterables to combine
  *
- * @return \Generator<array>
+ * @return \Iterator<array>
  */
-function product(iterable ...$iterables): \Generator {
+function product(iterable ...$iterables): \Iterator {
     $iterators = array_map('iter\\toIter', $iterables);
     $numIterators = \count($iterators);
     if (!$numIterators) {
@@ -548,9 +548,9 @@ function product(iterable ...$iterables): \Generator {
  * @param int $length Length (if not specified all remaining values from the
  *                    iterable are used)
  *
- * @return \Generator<T>
+ * @return \Iterator<T>
  */
-function slice(iterable $iterable, int $start, $length = PHP_INT_MAX): \Generator {
+function slice(iterable $iterable, int $start, $length = PHP_INT_MAX): \Iterator {
     if ($start < 0) {
         throw new \InvalidArgumentException('Start offset must be non-negative');
     }
@@ -586,9 +586,9 @@ function slice(iterable $iterable, int $start, $length = PHP_INT_MAX): \Generato
  * @param int $num Number of elements to take from the start
  * @param iterable<T> $iterable Iterable to take the elements from
  *
- * @return \Generator<T>
+ * @return \Iterator<T>
  */
-function take(int $num, iterable $iterable): \Generator {
+function take(int $num, iterable $iterable): \Iterator {
     return slice($iterable, 0, $num);
 }
 
@@ -605,9 +605,9 @@ function take(int $num, iterable $iterable): \Generator {
  * @param int $num Number of elements to drop from the start
  * @param iterable<T> $iterable Iterable to drop the elements from
  *
- * @return \Generator<T>
+ * @return \Iterator<T>
  */
-function drop(int $num, iterable $iterable): \Generator {
+function drop(int $num, iterable $iterable): \Iterator {
     return slice($iterable, $num);
 }
 
@@ -629,9 +629,9 @@ function drop(int $num, iterable $iterable): \Generator {
  *
  * @throws \InvalidArgumentException if num is negative
  *
- * @return \Generator<T>
+ * @return \Iterator<T>
  */
-function repeat($value, $num = PHP_INT_MAX): \Generator {
+function repeat($value, $num = PHP_INT_MAX): \Iterator {
     if ($num < 0) {
         throw new \InvalidArgumentException(
             'Number of repetitions must be non-negative');
@@ -655,9 +655,9 @@ function repeat($value, $num = PHP_INT_MAX): \Generator {
  *
  * @param iterable<TKey,TValue> $iterable Iterable to get keys from
  *
- * @return \Generator<TKey>
+ * @return \Iterator<TKey>
  */
-function keys(iterable $iterable): \Generator {
+function keys(iterable $iterable): \Iterator {
     foreach ($iterable as $key => $_) {
         yield $key;
     }
@@ -675,9 +675,9 @@ function keys(iterable $iterable): \Generator {
  *
  * @param iterable<T> $iterable Iterable to get values from
  *
- * @return \Generator<T>
+ * @return \Iterator<T>
  */
-function values(iterable $iterable): \Generator {
+function values(iterable $iterable): \Iterator {
     foreach ($iterable as $value) {
         yield $value;
     }
@@ -789,9 +789,9 @@ function search(callable $predicate, iterable $iterable) {
  * @param callable(T):bool $predicate Predicate: bool function(mixed $value)
  * @param iterable<T> $iterable Iterable to take values from
  *
- * @return \Generator<T>
+ * @return \Iterator<T>
  */
-function takeWhile(callable $predicate, iterable $iterable): \Generator {
+function takeWhile(callable $predicate, iterable $iterable): \Iterator {
     foreach ($iterable as $key => $value) {
         if (!$predicate($value)) {
             return;
@@ -817,9 +817,9 @@ function takeWhile(callable $predicate, iterable $iterable): \Generator {
  * @param callable(T):bool $predicate Predicate: bool function(mixed $value)
  * @param iterable<T> $iterable Iterable to drop values from
  *
- * @return \Generator<T>
+ * @return \Iterator<T>
  */
-function dropWhile(callable $predicate, iterable $iterable): \Generator {
+function dropWhile(callable $predicate, iterable $iterable): \Iterator {
     $failed = false;
     foreach ($iterable as $key => $value) {
         if (!$failed && !$predicate($value)) {
@@ -848,7 +848,7 @@ function dropWhile(callable $predicate, iterable $iterable): \Generator {
  * @param iterable $iterable Iterable to flatten
  * @param int $levels Number of levels to flatten
  *
- * @return \Generator
+ * @return \Iterator
  *
  * Note: Psalm does not support recursive type definitions yet, so it is not
  *       currently possible to correctly provide generic type information for
@@ -856,7 +856,7 @@ function dropWhile(callable $predicate, iterable $iterable): \Generator {
  * @see https://github.com/vimeo/psalm/issues/2777
  * @see https://github.com/vimeo/psalm/issues/5739
  */
-function flatten(iterable $iterable, $levels = PHP_INT_MAX): \Generator {
+function flatten(iterable $iterable, $levels = PHP_INT_MAX): \Iterator {
     if ($levels < 0) {
         throw new \InvalidArgumentException(
             'Number of levels must be non-negative'
@@ -900,9 +900,9 @@ function flatten(iterable $iterable, $levels = PHP_INT_MAX): \Generator {
  *
  * @param iterable<TKey,TValue> $iterable The iterable to flip
  *
- * @return \Generator<TValue,TKey>
+ * @return \Iterator<TValue,TKey>
  */
-function flip(iterable $iterable): \Generator {
+function flip(iterable $iterable): \Iterator {
     foreach ($iterable as $key => $value) {
         yield $value => $key;
     }
@@ -929,11 +929,11 @@ function flip(iterable $iterable): \Generator {
  *
  * @return (
  *      TPreserveKeys is true
- *      ? \Generator<array<TKey,TValue>>
- *      : \Generator<array<array-key,TValue>>
+ *      ? \Iterator<array<TKey,TValue>>
+ *      : \Iterator<array<array-key,TValue>>
  * ) An iterator of arrays
  */
-function chunk(iterable $iterable, int $size, bool $preserveKeys = false): \Generator {
+function chunk(iterable $iterable, int $size, bool $preserveKeys = false): \Iterator {
     if ($size <= 0) {
         throw new \InvalidArgumentException('Chunk size must be positive');
     }
@@ -974,9 +974,9 @@ function chunk(iterable $iterable, int $size, bool $preserveKeys = false): \Gene
  * @param iterable<TKey,TValue> $iterable The iterable to chunk
  * @param int $size The size of each chunk
  *
- * @return \Generator<array<TKey,TValue>> An iterator of arrays
+ * @return \Iterator<array<TKey,TValue>> An iterator of arrays
  */
-function chunkWithKeys(iterable $iterable, int $size): \Generator {
+function chunkWithKeys(iterable $iterable, int $size): \Iterator {
     return chunk($iterable, $size, true);
 }
 

--- a/src/iter.php
+++ b/src/iter.php
@@ -25,9 +25,9 @@ namespace iter;
  *
  * @throws \InvalidArgumentException if step is not valid
  *
- * @return \Iterator<int|float>
+ * @return \Generator<int|float>
  */
-function range($start, $end, $step = null): \Iterator {
+function range($start, $end, $step = null): \Generator {
     if ($start == $end) {
         yield $start;
     } elseif ($start < $end) {
@@ -78,9 +78,9 @@ function range($start, $end, $step = null): \Iterator {
  * @param iterable<T> $iterable Iterable to be mapped over
  * @psalm-param callable(T):U $function
  *
- * @return \Iterator<U>
+ * @return \Generator<U>
  */
-function map(callable $function, iterable $iterable): \Iterator {
+function map(callable $function, iterable $iterable): \Generator {
     foreach ($iterable as $key => $value) {
         yield $key => $function($value);
     }
@@ -106,9 +106,9 @@ function map(callable $function, iterable $iterable): \Iterator {
  * @param iterable<TKey,Value> $iterable Iterable those keys are to be mapped over
  * @psalm-param callable(TKey):UKey $function
  *
- * @return \Iterator<UKey,Value>
+ * @return \Generator<UKey,Value>
  */
-function mapKeys(callable $function, iterable $iterable): \Iterator {
+function mapKeys(callable $function, iterable $iterable): \Generator {
     foreach ($iterable as $key => $value) {
         yield $function($key) => $value;
     }
@@ -140,9 +140,9 @@ function mapKeys(callable $function, iterable $iterable): \Iterator {
  * @param iterable<TKey,T> $iterable Iterable to be mapped over
  * @psalm-param callable(T,TKey):U $function
  *
- * @return \Iterator<TKey,U>
+ * @return \Generator<TKey,U>
  */
-function mapWithKeys(callable $function, iterable $iterable): \Iterator {
+function mapWithKeys(callable $function, iterable $iterable): \Generator {
     foreach ($iterable as $key => $value) {
         yield $key => $function($value, $key);
     }
@@ -163,13 +163,13 @@ function mapWithKeys(callable $function, iterable $iterable): \Iterator {
  * @template T
  * @template U
  *
- * @param callable $function Mapping function: \Iterator function(mixed $value)
+ * @param callable $function Mapping function: \Generator function(mixed $value)
  * @param iterable<T> $iterable Iterable to be mapped over
  * @psalm-param callable(T):iterable<U> $function
  *
- * @return \Iterator<U>
+ * @return \Generator<U>
  */
-function flatMap(callable $function, iterable $iterable): \Iterator {
+function flatMap(callable $function, iterable $iterable): \Generator {
     foreach ($iterable as $value) {
         yield from $function($value);
     }
@@ -203,9 +203,9 @@ function flatMap(callable $function, iterable $iterable): \Iterator {
  * @param iterable<TKey,Value> $iterable Iterable to reindex
  * @psalm-param callable(Value):UKey $function
  *
- * @return \Iterator<UKey,Value>
+ * @return \Generator<UKey,Value>
  */
-function reindex(callable $function, iterable $iterable): \Iterator {
+function reindex(callable $function, iterable $iterable): \Generator {
     foreach ($iterable as $value) {
         yield $function($value) => $value;
     }
@@ -255,9 +255,9 @@ function apply(callable $function, iterable $iterable): void {
  * @param iterable<T> $iterable Iterable to filter
  * @psalm-param callable(T):bool $predicate
  *
- * @return \Iterator<T>
+ * @return \Generator<T>
  */
-function filter(callable $predicate, iterable $iterable): \Iterator {
+function filter(callable $predicate, iterable $iterable): \Generator {
     foreach ($iterable as $key => $value) {
         if ($predicate($value)) {
             yield $key => $value;
@@ -273,10 +273,10 @@ function filter(callable $predicate, iterable $iterable): \Iterator {
  *
  * @param iterable<TKey,TValue> $iterable Iterable to enumerate
  *
- * @return \Iterator<array>
- * @psalm-return \Iterator<array{0:TKey, 1:TValue}>
+ * @return \Generator<array>
+ * @psalm-return \Generator<array{0:TKey, 1:TValue}>
  */
-function enumerate(iterable $iterable): \Iterator {
+function enumerate(iterable $iterable): \Generator {
     return toPairs($iterable);
 }
 
@@ -298,10 +298,10 @@ function enumerate(iterable $iterable): \Iterator {
  *
  * @param iterable<TKey,TValue> $iterable Iterable to convert to pairs
  *
- * @return \Iterator<array>
- * @psalm-return \Iterator<array{0:TKey, 1:TValue}>
+ * @return \Generator<array>
+ * @psalm-return \Generator<array{0:TKey, 1:TValue}>
  */
-function toPairs(iterable $iterable): \Iterator {
+function toPairs(iterable $iterable): \Generator {
     foreach ($iterable as $key => $value) {
         yield [$key, $value];
     }
@@ -327,9 +327,9 @@ function toPairs(iterable $iterable): \Iterator {
  * @param iterable<array> $iterable Iterable of [key, value] pairs
  * @psalm-param iterable<array{0:TKey, 1:TValue}> $iterable
  *
- * @return \Iterator<TKey,TValue>
+ * @return \Generator<TKey,TValue>
  */
-function fromPairs(iterable $iterable): \Iterator {
+function fromPairs(iterable $iterable): \Generator {
     foreach ($iterable as [$key, $value]) {
         yield $key => $value;
     }
@@ -397,9 +397,9 @@ function reduce(callable $function, iterable $iterable, $startValue = null) {
  *                          Usually identity value of $function.
  * @psalm-param callable(TAcc,TValue,TKey):TAcc $function
  *
- * @return \Iterator<TAcc> Intermediate results of the reduction
+ * @return \Generator<TAcc> Intermediate results of the reduction
  */
-function reductions(callable $function, iterable $iterable, $startValue = null): \Iterator {
+function reductions(callable $function, iterable $iterable, $startValue = null): \Generator {
     $acc = $startValue;
     foreach ($iterable as $key => $value) {
         $acc = $function($acc, $value, $key);
@@ -419,11 +419,11 @@ function reductions(callable $function, iterable $iterable, $startValue = null):
  *     iter\zip([1, 2, 3], [4, 5, 6], [7, 8, 9])
  *     => iter([1, 4, 7], [2, 5, 8], [3, 6, 9])
  *
- * @param iterable[] ...$iterables Iterables to zip
+ * @param iterable ...$iterables Iterables to zip
  *
- * @return \Iterator<array>
+ * @return \Generator<array>
  */
-function zip(iterable ...$iterables): \Iterator {
+function zip(iterable ...$iterables): \Generator {
     if (\count($iterables) === 0) {
         return;
     }
@@ -453,9 +453,9 @@ function zip(iterable ...$iterables): \Iterator {
  * @param iterable<TKey> $keys Iterable of keys
  * @param iterable<TValue> $values Iterable of values
  *
- * @return \Iterator<TKey,TValue>
+ * @return \Generator<TKey,TValue>
  */
-function zipKeyValue(iterable $keys, iterable $values): \Iterator {
+function zipKeyValue(iterable $keys, iterable $values): \Generator {
     $keys = toIter($keys);
     $values = toIter($values);
 
@@ -483,9 +483,9 @@ function zipKeyValue(iterable $keys, iterable $values): \Iterator {
  *
  * @param iterable<T> ...$iterables Iterables to chain
  *
- * @return \Iterator<T>
+ * @return \Generator<T>
  */
-function chain(iterable ...$iterables): \Iterator {
+function chain(iterable ...$iterables): \Generator {
     foreach ($iterables as $iterable) {
         yield from $iterable;
     }
@@ -504,11 +504,11 @@ function chain(iterable ...$iterables): \Iterator {
  *     iter\product(iter\range(1, 2), iter\rewindable\range(3, 4))
  *     => iter([1, 3], [1, 4], [2, 3], [2, 4])
  *
- * @param iterable[] ...$iterables Iterables to combine
+ * @param iterable ...$iterables Iterables to combine
  *
- * @return \Iterator<array>
+ * @return \Generator<array>
  */
-function product(iterable ...$iterables): \Iterator {
+function product(iterable ...$iterables): \Generator {
     $iterators = array_map('iter\\toIter', $iterables);
     $numIterators = \count($iterators);
     if (!$numIterators) {
@@ -560,9 +560,9 @@ function product(iterable ...$iterables): \Iterator {
  * @param int $length Length (if not specified all remaining values from the
  *                    iterable are used)
  *
- * @return \Iterator<T>
+ * @return \Generator<T>
  */
-function slice(iterable $iterable, int $start, $length = PHP_INT_MAX): \Iterator {
+function slice(iterable $iterable, int $start, $length = PHP_INT_MAX): \Generator {
     if ($start < 0) {
         throw new \InvalidArgumentException('Start offset must be non-negative');
     }
@@ -598,9 +598,9 @@ function slice(iterable $iterable, int $start, $length = PHP_INT_MAX): \Iterator
  * @param int $num Number of elements to take from the start
  * @param iterable<T> $iterable Iterable to take the elements from
  *
- * @return \Iterator<T>
+ * @return \Generator<T>
  */
-function take(int $num, iterable $iterable): \Iterator {
+function take(int $num, iterable $iterable): \Generator {
     return slice($iterable, 0, $num);
 }
 
@@ -617,9 +617,9 @@ function take(int $num, iterable $iterable): \Iterator {
  * @param int $num Number of elements to drop from the start
  * @param iterable<T> $iterable Iterable to drop the elements from
  *
- * @return \Iterator<T>
+ * @return \Generator<T>
  */
-function drop(int $num, iterable $iterable): \Iterator {
+function drop(int $num, iterable $iterable): \Generator {
     return slice($iterable, $num);
 }
 
@@ -642,9 +642,9 @@ function drop(int $num, iterable $iterable): \Iterator {
  *
  * @throws \InvalidArgumentException if num is negative
  *
- * @return \Iterator<T>
+ * @return \Generator<T>
  */
-function repeat($value, $num = PHP_INT_MAX): \Iterator {
+function repeat($value, $num = PHP_INT_MAX): \Generator {
     if ($num < 0) {
         throw new \InvalidArgumentException(
             'Number of repetitions must be non-negative');
@@ -668,9 +668,9 @@ function repeat($value, $num = PHP_INT_MAX): \Iterator {
  *
  * @param iterable<TKey,TValue> $iterable Iterable to get keys from
  *
- * @return \Iterator<TKey>
+ * @return \Generator<TKey>
  */
-function keys(iterable $iterable): \Iterator {
+function keys(iterable $iterable): \Generator {
     foreach ($iterable as $key => $_) {
         yield $key;
     }
@@ -688,9 +688,9 @@ function keys(iterable $iterable): \Iterator {
  *
  * @param iterable<T> $iterable Iterable to get values from
  *
- * @return \Iterator<T>
+ * @return \Generator<T>
  */
-function values(iterable $iterable): \Iterator {
+function values(iterable $iterable): \Generator {
     foreach ($iterable as $value) {
         yield $value;
     }
@@ -807,9 +807,9 @@ function search(callable $predicate, iterable $iterable) {
  * @param iterable<T> $iterable Iterable to take values from
  * @psalm-param callable(T):bool $predicate
  *
- * @return \Iterator<T>
+ * @return \Generator<T>
  */
-function takeWhile(callable $predicate, iterable $iterable): \Iterator {
+function takeWhile(callable $predicate, iterable $iterable): \Generator {
     foreach ($iterable as $key => $value) {
         if (!$predicate($value)) {
             return;
@@ -836,9 +836,9 @@ function takeWhile(callable $predicate, iterable $iterable): \Iterator {
  * @param iterable<T> $iterable Iterable to drop values from
  * @psalm-param callable(T):bool $predicate
  *
- * @return \Iterator<T>
+ * @return \Generator<T>
  */
-function dropWhile(callable $predicate, iterable $iterable): \Iterator {
+function dropWhile(callable $predicate, iterable $iterable): \Generator {
     $failed = false;
     foreach ($iterable as $key => $value) {
         if (!$failed && !$predicate($value)) {
@@ -867,7 +867,7 @@ function dropWhile(callable $predicate, iterable $iterable): \Iterator {
  * @param iterable $iterable Iterable to flatten
  * @param int $levels Number of levels to flatten
  *
- * @return \Iterator
+ * @return \Generator
  *
  * Note: Psalm does not support recursive type definitions yet, so it is not
  *       currently possible to correctly provide generic type information for
@@ -875,7 +875,7 @@ function dropWhile(callable $predicate, iterable $iterable): \Iterator {
  * @see https://github.com/vimeo/psalm/issues/2777
  * @see https://github.com/vimeo/psalm/issues/5739
  */
-function flatten(iterable $iterable, int $levels = PHP_INT_MAX): \Iterator {
+function flatten(iterable $iterable, $levels = PHP_INT_MAX): \Generator {
     if ($levels < 0) {
         throw new \InvalidArgumentException(
             'Number of levels must be non-negative'
@@ -919,9 +919,9 @@ function flatten(iterable $iterable, int $levels = PHP_INT_MAX): \Iterator {
  *
  * @param iterable<TKey,TValue> $iterable The iterable to flip
  *
- * @return \Iterator<TValue,TKey>
+ * @return \Generator<TValue,TKey>
  */
-function flip(iterable $iterable): \Iterator {
+function flip(iterable $iterable): \Generator {
     foreach ($iterable as $key => $value) {
         yield $value => $key;
     }
@@ -946,10 +946,10 @@ function flip(iterable $iterable): \Iterator {
  * @param int $size The size of each chunk
  * @param TPreserve $preserveKeys Whether to preserve keys from the input iterable
  *
- * @return \Iterator<array> An iterator of arrays
- * @psalm-return (TPreserve is true ? \Iterator<array<TKey,TValue>> : \Iterator<array<array-key,TValue>>)
+ * @return \Generator<array> An iterator of arrays
+ * @psalm-return (TPreserve is true ? \Generator<array<TKey,TValue>> : \Generator<array<array-key,TValue>>)
  */
-function chunk(iterable $iterable, int $size, bool $preserveKeys = false): \Iterator {
+function chunk(iterable $iterable, int $size, bool $preserveKeys = false): \Generator {
     if ($size <= 0) {
         throw new \InvalidArgumentException('Chunk size must be positive');
     }
@@ -990,9 +990,9 @@ function chunk(iterable $iterable, int $size, bool $preserveKeys = false): \Iter
  * @param iterable<TKey,TValue> $iterable The iterable to chunk
  * @param int $size The size of each chunk
  *
- * @return \Iterator<array<TKey,TValue>> An iterator of arrays
+ * @return \Generator<array<TKey,TValue>> An iterator of arrays
  */
-function chunkWithKeys(iterable $iterable, int $size): \Iterator {
+function chunkWithKeys(iterable $iterable, int $size): \Generator {
     return chunk($iterable, $size, true);
 }
 

--- a/src/iter.php
+++ b/src/iter.php
@@ -74,9 +74,8 @@ function range($start, $end, $step = null): \Generator {
  * @template T
  * @template U
  *
- * @param callable $function Mapping function: mixed function(mixed $value)
+ * @param callable(T):U $function Mapping function: mixed function(mixed $value)
  * @param iterable<T> $iterable Iterable to be mapped over
- * @psalm-param callable(T):U $function
  *
  * @return \Generator<U>
  */
@@ -102,9 +101,8 @@ function map(callable $function, iterable $iterable): \Generator {
  * @template UKey
  * @template Value
  *
- * @param callable $function Mapping function: mixed function(mixed $key)
+ * @param callable(TKey):UKey $function Mapping function: mixed function(mixed $key)
  * @param iterable<TKey,Value> $iterable Iterable those keys are to be mapped over
- * @psalm-param callable(TKey):UKey $function
  *
  * @return \Generator<UKey,Value>
  */
@@ -136,9 +134,8 @@ function mapKeys(callable $function, iterable $iterable): \Generator {
  * @template T
  * @template U
  *
- * @param callable $function Mapping function: mixed function(mixed $value, mixed $key)
+ * @param callable(T,TKey):U $function Mapping function: mixed function(mixed $value, mixed $key)
  * @param iterable<TKey,T> $iterable Iterable to be mapped over
- * @psalm-param callable(T,TKey):U $function
  *
  * @return \Generator<TKey,U>
  */
@@ -163,9 +160,8 @@ function mapWithKeys(callable $function, iterable $iterable): \Generator {
  * @template T
  * @template U
  *
- * @param callable $function Mapping function: \Generator function(mixed $value)
+ * @param callable(T):iterable<U> $function Mapping function: \Generator function(mixed $value)
  * @param iterable<T> $iterable Iterable to be mapped over
- * @psalm-param callable(T):iterable<U> $function
  *
  * @return \Generator<U>
  */
@@ -199,9 +195,8 @@ function flatMap(callable $function, iterable $iterable): \Generator {
  * @template UKey
  * @template Value
  *
- * @param callable $function Mapping function mixed function(mixed $value)
+ * @param callable(Value):UKey $function Mapping function mixed function(mixed $value)
  * @param iterable<TKey,Value> $iterable Iterable to reindex
- * @psalm-param callable(Value):UKey $function
  *
  * @return \Generator<UKey,Value>
  */
@@ -225,9 +220,8 @@ function reindex(callable $function, iterable $iterable): \Generator {
  *
  * @template T
  *
- * @param callable $function Apply function: void function(mixed $value)
+ * @param callable(T):void $function Apply function: void function(mixed $value)
  * @param iterable<T> $iterable Iterator to apply on
- * @psalm-param callable(T):void $function
  */
 function apply(callable $function, iterable $iterable): void {
     foreach ($iterable as $value) {
@@ -251,9 +245,8 @@ function apply(callable $function, iterable $iterable): void {
  *
  * @template T
  *
- * @param callable $predicate Predicate: bool function(mixed $value)
+ * @param callable(T):bool $predicate Predicate: bool function(mixed $value)
  * @param iterable<T> $iterable Iterable to filter
- * @psalm-param callable(T):bool $predicate
  *
  * @return \Generator<T>
  */
@@ -273,8 +266,7 @@ function filter(callable $predicate, iterable $iterable): \Generator {
  *
  * @param iterable<TKey,TValue> $iterable Iterable to enumerate
  *
- * @return \Generator<array>
- * @psalm-return \Generator<array{0:TKey, 1:TValue}>
+ * @return \Generator<array{0:TKey, 1:TValue}>
  */
 function enumerate(iterable $iterable): \Generator {
     return toPairs($iterable);
@@ -298,8 +290,7 @@ function enumerate(iterable $iterable): \Generator {
  *
  * @param iterable<TKey,TValue> $iterable Iterable to convert to pairs
  *
- * @return \Generator<array>
- * @psalm-return \Generator<array{0:TKey, 1:TValue}>
+ * @return \Generator<array{0:TKey, 1:TValue}>
  */
 function toPairs(iterable $iterable): \Generator {
     foreach ($iterable as $key => $value) {
@@ -324,8 +315,7 @@ function toPairs(iterable $iterable): \Generator {
  * @template TKey
  * @template TValue
  *
- * @param iterable<array> $iterable Iterable of [key, value] pairs
- * @psalm-param iterable<array{0:TKey, 1:TValue}> $iterable
+ * @param iterable<array{0:TKey, 1:TValue}> $iterable Iterable of [key, value] pairs
  *
  * @return \Generator<TKey,TValue>
  */
@@ -353,12 +343,11 @@ function fromPairs(iterable $iterable): \Generator {
  * @template TValue
  * @template TAcc
  *
- * @param callable $function Reduction function:
- *                           mixed function(mixed $acc, mixed $value, mixed $key)
+ * @param callable(TAcc,TValue,TKey):TAcc $function Reduction function:
+ *                                                  mixed function(mixed $acc, mixed $value, mixed $key)
  * @param iterable<TKey,TValue> $iterable Iterable to reduce
  * @param TAcc $startValue Start value for accumulator.
- *                          Usually identity value of $function.
- * @psalm-param callable(TAcc,TValue,TKey):TAcc $function
+ *                         Usually identity value of $function.
  *
  * @return TAcc Result of the reduction
  */
@@ -390,12 +379,11 @@ function reduce(callable $function, iterable $iterable, $startValue = null) {
  * @template TValue
  * @template TAcc
  *
- * @param callable $function Reduction function:
+ * @param callable(TAcc,TValue,TKey):TAcc $function Reduction function:
  *                           mixed function(mixed $acc, mixed $value, mixed $key)
  * @param iterable<TKey,TValue> $iterable Iterable to reduce
  * @param TAcc $startValue Start value for accumulator.
  *                          Usually identity value of $function.
- * @psalm-param callable(TAcc,TValue,TKey):TAcc $function
  *
  * @return \Generator<TAcc> Intermediate results of the reduction
  */
@@ -636,9 +624,8 @@ function drop(int $num, iterable $iterable): \Generator {
  *
  * @template T
  *
- * @param mixed $value Value to repeat
- * @param int   $num   Number of repetitions (defaults to PHP_INT_MAX)
- * @psalm-param T $value
+ * @param T   $value Value to repeat
+ * @param int $num   Number of repetitions (defaults to PHP_INT_MAX)
  *
  * @throws \InvalidArgumentException if num is negative
  *
@@ -712,9 +699,8 @@ function values(iterable $iterable): \Generator {
  *
  * @template T
  *
- * @param callable $predicate Predicate: bool function(mixed $value)
+ * @param callable(T):bool $predicate Predicate: bool function(mixed $value)
  * @param iterable<T> $iterable Iterable to check against the predicate
- * @psalm-param callable(T):bool $predicate
  *
  * @return bool Whether the predicate matches any value
  */
@@ -743,9 +729,8 @@ function any(callable $predicate, iterable $iterable): bool {
  *
  * @template T
  *
- * @param callable $predicate Predicate: bool function(mixed $value)
+ * @param callable(T):bool $predicate Predicate: bool function(mixed $value)
  * @param iterable<T> $iterable Iterable to check against the predicate
- * @psalm-param callable(T):bool $predicate
  *
  * @return bool Whether the predicate holds for all values
  */
@@ -773,12 +758,10 @@ function all(callable $predicate, iterable $iterable): bool {
  *
  * @template T
  *
- * @param callable $predicate Predicate: bool function(mixed $value)
+ * @param callable(T):bool $predicate Predicate: bool function(mixed $value)
  * @param iterable<T> $iterable The iterable to search
- * @psalm-param callable(T):bool $predicate
  *
- * @return null|mixed
- * @psalm-return T|null
+ * @return T|null
  */
 function search(callable $predicate, iterable $iterable) {
     foreach ($iterable as $value) {
@@ -803,9 +786,8 @@ function search(callable $predicate, iterable $iterable) {
  *
  * @template T
  *
- * @param callable $predicate Predicate: bool function(mixed $value)
+ * @param callable(T):bool $predicate Predicate: bool function(mixed $value)
  * @param iterable<T> $iterable Iterable to take values from
- * @psalm-param callable(T):bool $predicate
  *
  * @return \Generator<T>
  */
@@ -832,9 +814,8 @@ function takeWhile(callable $predicate, iterable $iterable): \Generator {
  *
  * @template T
  *
- * @param callable $predicate Predicate: bool function(mixed $value)
+ * @param callable(T):bool $predicate Predicate: bool function(mixed $value)
  * @param iterable<T> $iterable Iterable to drop values from
- * @psalm-param callable(T):bool $predicate
  *
  * @return \Generator<T>
  */
@@ -940,14 +921,17 @@ function flip(iterable $iterable): \Generator {
  *
  * @template TKey
  * @template TValue
- * @template TPreserve of bool
+ * @template TPreserveKeys of bool
  *
  * @param iterable<TKey,TValue> $iterable The iterable to chunk
  * @param int $size The size of each chunk
- * @param TPreserve $preserveKeys Whether to preserve keys from the input iterable
+ * @param TPreserveKeys $preserveKeys Whether to preserve keys from the input iterable
  *
- * @return \Generator<array> An iterator of arrays
- * @psalm-return (TPreserve is true ? \Generator<array<TKey,TValue>> : \Generator<array<array-key,TValue>>)
+ * @return (
+ *      TPreserveKeys is true
+ *      ? \Generator<array<TKey,TValue>>
+ *      : \Generator<array<array-key,TValue>>
+ * ) An iterator of arrays
  */
 function chunk(iterable $iterable, int $size, bool $preserveKeys = false): \Generator {
     if ($size <= 0) {

--- a/src/iter.rewindable.php
+++ b/src/iter.rewindable.php
@@ -19,7 +19,7 @@ namespace iter {
      *
      * @param callable(...mixed):\Iterator<TKey,TValue> $function Iterator factory function
      *
-     * @return callable(...mixed):\Iterator<TKey,TValue> Rewindable generator function
+     * @return callable(...mixed):\Iterator<TKey,TValue> Rewindable iterator factory function
      */
     function makeRewindable(callable $function) {
         return function(...$args) use ($function) {

--- a/src/iter.rewindable.php
+++ b/src/iter.rewindable.php
@@ -17,11 +17,9 @@ namespace iter {
      * @template TKey
      * @template TValue
      *
-     * @param callable $function Generator function to make rewindable
-     * @psalm-param callable(...mixed):\Generator<TKey,TValue> $function
+     * @param callable(...mixed):\Generator<TKey,TValue> $function Generator function to make rewindable
      *
-     * @return callable Rewindable generator function
-     * @psalm-return callable(...mixed):\Iterator<TKey,TValue>
+     * @return callable(...mixed):\Iterator<TKey,TValue> Rewindable generator function
      */
     function makeRewindable(callable $function) {
         return function(...$args) use ($function) {
@@ -45,12 +43,10 @@ namespace iter {
      * @template TKey
      * @template TValue
      *
-     * @param callable $function Generator function to call rewindably
+     * @param callable(...mixed):\Generator<TKey,TValue> $function Generator function to call rewindably
      * @param mixed ...$args Function arguments
-     * @psalm-param callable(...mixed):\Generator<TKey,TValue> $function
      *
-     * @return \Iterator Rewindable generator result
-     * @psalm-return \Iterator<TKey,TValue>
+     * @return \Iterator<TKey,TValue> Rewindable generator result
      */
     function callRewindable(callable $function, ...$args) {
         return new rewindable\_RewindableGenerator($function, $args);

--- a/src/iter.rewindable.php
+++ b/src/iter.rewindable.php
@@ -2,10 +2,10 @@
 
 namespace iter {
     /**
-     * Converts a generator function into a rewindable generator function.
+     * Creates a rewindable iterator from a non-rewindable iterator.
      *
      * This is implemented simply be remembering the arguments with which the
-     * generator function is later called and just calling it again if a
+     * factory function is later called and just calling it again if a
      * rewind() occurs.
      *
      * Example:
@@ -17,23 +17,23 @@ namespace iter {
      * @template TKey
      * @template TValue
      *
-     * @param callable(...mixed):\Generator<TKey,TValue> $function Generator function to make rewindable
+     * @param callable(...mixed):\Iterator<TKey,TValue> $function Iterator factory function
      *
      * @return callable(...mixed):\Iterator<TKey,TValue> Rewindable generator function
      */
     function makeRewindable(callable $function) {
         return function(...$args) use ($function) {
-            return new rewindable\_RewindableGenerator($function, $args);
+            return new rewindable\_RewindableIterator($function, $args);
         };
     }
 
     /**
-     * Call a generator function, but make the result rewindable.
+     * Creates a rewindable iterator from a non-rewindable iterator.
      *
-     * This function does basically the same thing as makeRewindable(), but it
-     * directly calls the function, rather than returning a lambda. Useful if
-     * you want to do a one-off call, rather than using the rewindable function
-     * multiple times.
+     * This function does basically the same thing as makeRewindable(),
+     * but it directly calls the function, rather than returning a lambda.
+     * Useful if you want to do a one-off call, rather than using the rewindable
+     * function multiple times.
      *
      * Example:
      *
@@ -43,13 +43,13 @@ namespace iter {
      * @template TKey
      * @template TValue
      *
-     * @param callable(...mixed):\Generator<TKey,TValue> $function Generator function to call rewindably
+     * @param callable(...mixed):\Iterator<TKey,TValue> $function Iterator factory function
      * @param mixed ...$args Function arguments
      *
      * @return \Iterator<TKey,TValue> Rewindable generator result
      */
     function callRewindable(callable $function, ...$args) {
-        return new rewindable\_RewindableGenerator($function, $args);
+        return new rewindable\_RewindableIterator($function, $args);
     }
 }
 
@@ -62,79 +62,79 @@ namespace iter\rewindable {
      * non-rewindable functions from the iter namespace
      */
 
-    function range()         { return new _RewindableGenerator('iter\range',         func_get_args()); }
-    function map()           { return new _RewindableGenerator('iter\map',           func_get_args()); }
-    function mapKeys()       { return new _RewindableGenerator('iter\mapKeys',       func_get_args()); }
-    function mapWithKeys()   { return new _RewindableGenerator('iter\mapWithKeys',   func_get_args()); }
-    function flatMap()       { return new _RewindableGenerator('iter\flatMap',       func_get_args()); }
-    function reindex()       { return new _RewindableGenerator('iter\reindex',       func_get_args()); }
-    function filter()        { return new _RewindableGenerator('iter\filter',        func_get_args()); }
-    function enumerate()     { return new _RewindableGenerator('iter\enumerate',     func_get_args()); }
-    function toPairs()       { return new _RewindableGenerator('iter\toPairs',       func_get_args()); }
-    function fromPairs()     { return new _RewindableGenerator('iter\fromPairs',     func_get_args()); }
-    function reductions()    { return new _RewindableGenerator('iter\reductions',    func_get_args()); }
-    function zip()           { return new _RewindableGenerator('iter\zip',           func_get_args()); }
-    function zipKeyValue()   { return new _RewindableGenerator('iter\zipKeyValue',   func_get_args()); }
-    function chain()         { return new _RewindableGenerator('iter\chain',         func_get_args()); }
-    function product()       { return new _RewindableGenerator('iter\product',       func_get_args()); }
-    function slice()         { return new _RewindableGenerator('iter\slice',         func_get_args()); }
-    function take()          { return new _RewindableGenerator('iter\take',          func_get_args()); }
-    function drop()          { return new _RewindableGenerator('iter\drop',          func_get_args()); }
-    function repeat()        { return new _RewindableGenerator('iter\repeat',        func_get_args()); }
-    function takeWhile()     { return new _RewindableGenerator('iter\takeWhile',     func_get_args()); }
-    function dropWhile()     { return new _RewindableGenerator('iter\dropWhile',     func_get_args()); }
-    function keys()          { return new _RewindableGenerator('iter\keys',          func_get_args()); }
-    function values()        { return new _RewindableGenerator('iter\values',        func_get_args()); }
-    function flatten()       { return new _RewindableGenerator('iter\flatten',       func_get_args()); }
-    function flip()          { return new _RewindableGenerator('iter\flip',          func_get_args()); }
-    function chunk()         { return new _RewindableGenerator('iter\chunk',         func_get_args()); }
-    function chunkWithKeys() { return new _RewindableGenerator('iter\chunkWithKeys', func_get_args()); }
+    function range()         { return new _RewindableIterator('iter\range',         func_get_args()); }
+    function map()           { return new _RewindableIterator('iter\map',           func_get_args()); }
+    function mapKeys()       { return new _RewindableIterator('iter\mapKeys',       func_get_args()); }
+    function mapWithKeys()   { return new _RewindableIterator('iter\mapWithKeys',   func_get_args()); }
+    function flatMap()       { return new _RewindableIterator('iter\flatMap',       func_get_args()); }
+    function reindex()       { return new _RewindableIterator('iter\reindex',       func_get_args()); }
+    function filter()        { return new _RewindableIterator('iter\filter',        func_get_args()); }
+    function enumerate()     { return new _RewindableIterator('iter\enumerate',     func_get_args()); }
+    function toPairs()       { return new _RewindableIterator('iter\toPairs',       func_get_args()); }
+    function fromPairs()     { return new _RewindableIterator('iter\fromPairs',     func_get_args()); }
+    function reductions()    { return new _RewindableIterator('iter\reductions',    func_get_args()); }
+    function zip()           { return new _RewindableIterator('iter\zip',           func_get_args()); }
+    function zipKeyValue()   { return new _RewindableIterator('iter\zipKeyValue',   func_get_args()); }
+    function chain()         { return new _RewindableIterator('iter\chain',         func_get_args()); }
+    function product()       { return new _RewindableIterator('iter\product',       func_get_args()); }
+    function slice()         { return new _RewindableIterator('iter\slice',         func_get_args()); }
+    function take()          { return new _RewindableIterator('iter\take',          func_get_args()); }
+    function drop()          { return new _RewindableIterator('iter\drop',          func_get_args()); }
+    function repeat()        { return new _RewindableIterator('iter\repeat',        func_get_args()); }
+    function takeWhile()     { return new _RewindableIterator('iter\takeWhile',     func_get_args()); }
+    function dropWhile()     { return new _RewindableIterator('iter\dropWhile',     func_get_args()); }
+    function keys()          { return new _RewindableIterator('iter\keys',          func_get_args()); }
+    function values()        { return new _RewindableIterator('iter\values',        func_get_args()); }
+    function flatten()       { return new _RewindableIterator('iter\flatten',       func_get_args()); }
+    function flip()          { return new _RewindableIterator('iter\flip',          func_get_args()); }
+    function chunk()         { return new _RewindableIterator('iter\chunk',         func_get_args()); }
+    function chunkWithKeys() { return new _RewindableIterator('iter\chunkWithKeys', func_get_args()); }
 
     /**
-     * This class is used for the internal implementation of rewindable
-     * generators. Should not be used directly, instead use makeRewindable() or
-     * callRewindable().
+     * This class is used for the internal implementation of iterators that are
+     * otherwise not rewindable. Should not be used directly, instead use
+     * makeRewindable() or callRewindable().
      *
      * @template TKey
-     * @template TYield
-     * @template TSend
-     * @template TReturn
+     * @template TValue
      *
-     * @implements \Iterator<TKey,TYield>
+     * @implements \Iterator<TKey,TValue>
      *
      * @internal
      */
-    class _RewindableGenerator implements \Iterator {
+    class _RewindableIterator implements \Iterator {
         /** @var callable */
         protected $function;
 
         /** @var mixed[] */
         protected $args;
 
-        /** @var \Generator<TKey,TYield,TSend,TReturn>|null */
-        protected $generator;
+        /** @var \Iterator<TKey,TValue> */
+        protected $iterator;
 
+        /**
+         * @param callable(...mixed):\Iterator<TKey,TValue> $function
+         * @param mixed[] $args
+         */
         public function __construct(callable $function, array $args) {
             $this->function = $function;
             $this->args = $args;
-            $this->generator = null;
+            $this->iterator = null;
         }
 
         public function rewind(): void {
             $function = $this->function;
-            $this->generator = $function(...$this->args);
+            $this->iterator = $function(...$this->args);
         }
 
         public function next(): void {
-            if (!$this->generator) { $this->rewind(); }
-            /** @var \Generator<TKey,TYield,TSend,TReturn> $this->generator */
-            $this->generator->next();
+            if (!$this->iterator) { $this->rewind(); }
+            $this->iterator->next();
         }
 
         public function valid(): bool {
-            if (!$this->generator) { $this->rewind(); }
-            /** @var \Generator<TKey,TYield,TSend,TReturn> $this->generator */
-            return $this->generator->valid();
+            if (!$this->iterator) { $this->rewind(); }
+            return $this->iterator->valid();
         }
 
         /**
@@ -142,9 +142,8 @@ namespace iter\rewindable {
          */
         #[ReturnTypeWillChange]
         public function key() {
-            if (!$this->generator) { $this->rewind(); }
-            /** @var \Generator<TKey,TYield,TSend,TReturn> $this->generator */
-            return $this->generator->key();
+            if (!$this->iterator) { $this->rewind(); }
+            return $this->iterator->key();
         }
 
         /**
@@ -152,9 +151,38 @@ namespace iter\rewindable {
          */
         #[ReturnTypeWillChange]
         public function current() {
-            if (!$this->generator) { $this->rewind(); }
-            /** @var \Generator<TKey,TYield,TSend,TReturn> $this->generator */
-            return $this->generator->current();
+            if (!$this->iterator) { $this->rewind(); }
+            return $this->iterator->current();
+        }
+    }
+
+    /**
+     * This class was used for the internal implementation of rewindable
+     * generators. This has been deprecated in favor of the more general
+     * _RewindableIterator class, and may be removed in a future version.
+     *
+     * @template TKey
+     * @template TYield
+     * @template TSend
+     * @template TReturn
+     *
+     * @extends _RewindableIterator<TKey,TYield>
+     *
+     * @internal
+     * @deprecated
+     */
+    class _RewindableGenerator extends _RewindableIterator {
+        /** @var \Generator<TKey,TYield,TSend,TReturn> */
+        protected $iterator;
+
+        /**
+         * @param callable(...mixed):\Generator<TKey,TYield,TSend,TReturn> $function
+         * @param mixed[] $args
+         */
+        public function __construct(callable $function, array $args) {
+            $this->function = $function;
+            $this->args = $args;
+            $this->iterator = null;
         }
 
         /**
@@ -162,9 +190,8 @@ namespace iter\rewindable {
          * @return TYield|null
          */
         public function send($value = null) {
-            if (!$this->generator) { $this->rewind(); }
-            /** @var \Generator<TKey,TYield,TSend,TReturn> $this->generator */
-            return $this->generator->send($value);
+            if (!$this->iterator) { $this->rewind(); }
+            return $this->iterator->send($value);
         }
 
         /**
@@ -172,9 +199,8 @@ namespace iter\rewindable {
          * @return TYield
          */
         public function throw($exception) {
-            if (!$this->generator) { $this->rewind(); }
-            /** @var \Generator<TKey,TYield,TSend,TReturn> $this->generator */
-            return $this->generator->throw($exception);
+            if (!$this->iterator) { $this->rewind(); }
+            return $this->iterator->throw($exception);
         }
     }
 }

--- a/src/iter.rewindable.php
+++ b/src/iter.rewindable.php
@@ -14,9 +14,14 @@ namespace iter {
      *      $res = $rewindableMap(func\operator('*', 3), [1, 2, 3]);
      *      // $res is a rewindable iterator with elements [3, 6, 9]
      *
+     * @template TKey
+     * @template TValue
+     *
      * @param callable $function Generator function to make rewindable
+     * @psalm-param callable(...mixed):\Generator<TKey,TValue> $function
      *
      * @return callable Rewindable generator function
+     * @psalm-return callable(...mixed):\Iterator<TKey,TValue>
      */
     function makeRewindable(callable $function) {
         return function(...$args) use ($function) {
@@ -37,10 +42,15 @@ namespace iter {
      *      $res = iter\callRewindable('iter\\map', func\operator('*', 3), [1, 2, 3]);
      *      // $res is a rewindable iterator with elements [3, 6, 9]
      *
+     * @template TKey
+     * @template TValue
+     *
      * @param callable $function Generator function to call rewindably
      * @param mixed ...$args Function arguments
+     * @psalm-param callable(...mixed):\Generator<TKey,TValue> $function
      *
      * @return \Iterator Rewindable generator result
+     * @psalm-return \Iterator<TKey,TValue>
      */
     function callRewindable(callable $function, ...$args) {
         return new rewindable\_RewindableGenerator($function, $args);
@@ -89,12 +99,23 @@ namespace iter\rewindable {
      * generators. Should not be used directly, instead use makeRewindable() or
      * callRewindable().
      *
+     * @template TKey
+     * @template TYield
+     * @template TSend
+     * @template TReturn
+     *
+     * @implements \Iterator<TKey,TYield>
+     *
      * @internal
      */
     class _RewindableGenerator implements \Iterator {
+        /** @var callable */
         protected $function;
+
+        /** @var mixed[] */
         protected $args;
-        /** @var \Generator */
+
+        /** @var \Generator<TKey,TYield,TSend,TReturn>|null */
         protected $generator;
 
         public function __construct(callable $function, array $args) {
@@ -110,11 +131,13 @@ namespace iter\rewindable {
 
         public function next(): void {
             if (!$this->generator) { $this->rewind(); }
+            /** @var \Generator<TKey,TYield,TSend,TReturn> $this->generator */
             $this->generator->next();
         }
 
         public function valid(): bool {
             if (!$this->generator) { $this->rewind(); }
+            /** @var \Generator<TKey,TYield,TSend,TReturn> $this->generator */
             return $this->generator->valid();
         }
 
@@ -124,6 +147,7 @@ namespace iter\rewindable {
         #[ReturnTypeWillChange]
         public function key() {
             if (!$this->generator) { $this->rewind(); }
+            /** @var \Generator<TKey,TYield,TSend,TReturn> $this->generator */
             return $this->generator->key();
         }
 
@@ -133,16 +157,27 @@ namespace iter\rewindable {
         #[ReturnTypeWillChange]
         public function current() {
             if (!$this->generator) { $this->rewind(); }
+            /** @var \Generator<TKey,TYield,TSend,TReturn> $this->generator */
             return $this->generator->current();
         }
 
+        /**
+         * @param mixed $value
+         * @return TYield|null
+         */
         public function send($value = null) {
             if (!$this->generator) { $this->rewind(); }
+            /** @var \Generator<TKey,TYield,TSend,TReturn> $this->generator */
             return $this->generator->send($value);
         }
 
+        /**
+         * @param \Throwable $exception
+         * @return TYield
+         */
         public function throw($exception) {
             if (!$this->generator) { $this->rewind(); }
+            /** @var \Generator<TKey,TYield,TSend,TReturn> $this->generator */
             return $this->generator->throw($exception);
         }
     }

--- a/test/IterRewindableTest.php
+++ b/test/IterRewindableTest.php
@@ -180,7 +180,7 @@ class IterRewindableTest extends TestCase {
     }
 
     public function testFirstMethod() {
-        /** @psalm-var callable():rewindable\_RewindableGenerator $genFn */
+        /** @var callable():rewindable\_RewindableGenerator $genFn */
         $genFn = makeRewindable(function() {
             try {
                 yield 1 => 2;

--- a/test/IterRewindableTest.php
+++ b/test/IterRewindableTest.php
@@ -154,6 +154,7 @@ class IterRewindableTest extends TestCase {
     public function testRewindableGenerator() {
         // Make sure that send() and throw() work with rewindable generator
         $genFn = makeRewindable(function() {
+            /** @psalm-suppress NoValue as this is to test send works */
             $startValue = yield;
             try {
                 for (;;) yield $startValue++;
@@ -179,6 +180,7 @@ class IterRewindableTest extends TestCase {
     }
 
     public function testFirstMethod() {
+        /** @psalm-var callable():rewindable\_RewindableGenerator $genFn */
         $genFn = makeRewindable(function() {
             try {
                 yield 1 => 2;

--- a/test/iterTest.php
+++ b/test/iterTest.php
@@ -22,7 +22,6 @@ class IterTest extends TestCase {
         ];
     }
 
-    
     public function testRangeStepMustBePositive() {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('If start < end the step must be positive');
@@ -30,7 +29,6 @@ class IterTest extends TestCase {
         toArray(range(0, 10, -1));
     }
 
-    
     public function testRangeStepMustBeNegative() {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('If start > end the step must be negative');
@@ -201,7 +199,6 @@ class IterTest extends TestCase {
         toArray(slice(range(0, INF), 0, -1));
     }
 
-    
     public function testSliceNegativeStartOffsetError() {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Start offset must be non-negative');
@@ -228,7 +225,6 @@ class IterTest extends TestCase {
         $this->assertSame([], toArray(repeat(1, 0)));
     }
 
-    
     public function testRepeatNegativeNumError() {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Number of repetitions must be non-negative');
@@ -362,7 +358,6 @@ class IterTest extends TestCase {
         );
     }
 
-    
     public function testFlattenNegativeLevelError() {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Number of levels must be non-negative');
@@ -497,7 +492,6 @@ class IterTest extends TestCase {
         );
     }
 
-    
     public function testZeroChunkSizeError() {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Chunk size must be positive');
@@ -505,7 +499,6 @@ class IterTest extends TestCase {
         toArray(chunk([1, 2, 3], 0));
     }
 
-    
     public function testNegativeChunkSizeError() {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Chunk size must be positive');
@@ -583,22 +576,26 @@ class IterTest extends TestCase {
 
     public function provideTestAssertIterableFails() {
         yield [
+            /** @psalm-suppress InvalidArgument as this is expected */
             function() { return count(new \stdClass()); },
             'Argument must be iterable or implement Countable',
             \InvalidArgumentException::class
         ];
         yield [
+            /** @psalm-suppress InvalidArgument as this is expected */
             function() { return isEmpty(new \stdClass()); },
             'Argument must be iterable or implement Countable',
             \InvalidArgumentException::class
         ];
         yield [
+            /** @psalm-suppress InvalidArgument as this is expected */
             function() { return toIter(new \stdClass()); },
             null,
             \TypeError::class
         ];
         yield [
             function() {
+                /** @psalm-suppress InvalidArgument as this is expected */
                 return map(function($v) { return $v; }, new \stdClass());
             },
             null,
@@ -606,6 +603,7 @@ class IterTest extends TestCase {
         ];
         yield [
             function() {
+                /** @psalm-suppress InvalidArgument as this is expected */
                 return chain([1], [2], new \stdClass());
             },
             null,
@@ -613,6 +611,7 @@ class IterTest extends TestCase {
         ];
         yield [
             function() {
+                /** @psalm-suppress InvalidArgument as this is expected */
                 return zip([1], [2], new \stdClass());
             },
             null,


### PR DESCRIPTION
Should go a ways towards https://github.com/nikic/iter/issues/83

I've been using this library in a few of my projects, and found myself wanting these annotations.

Some notes about this PR:

- PR adds `vimeo/psalm` as a `require-dev` dependency (`^4.18` for PHP >= 7.1, `^5.13` for PHP >= 7.4). This also adds a default Psalm config file (`psalm.xml`).
- Updated the return types of many functions in the main `iter\` namespace to return `\Generator` instead of `\Iterator`. This is to satisfy the type requirements of `makeRewindable` and `callRewindable`, and is actually what these functions return.
- Psalm flagged an issue in `isEmpty()`, as `\IteratorAggregate->getIterator()` only returns `\Traversable`, not `\Iterator`.
  In the edge case that the returned `\Traversable` is not also `\Iterator`, this could have caused an issue.
  This is fixed in this PR.
- In functions that take a `$levels = INF` parameter or similar, changed `INF` to `PHP_INT_MAX` as `INF` is a float type and not int as declared. In these cases, `$levels` can never exceed the `PHP_INT_MAX` anyhow.
- Psalm does not have support for recursive types. Functions which use recursive types have had a note added to the
  docblock to explain this.
- I've not added docblocks to the functions in the `\iter\rewindable` namespace, as that would necessarily mean that any changes to the regular function would also need to be reflected in the docblocks for these methods. This does mean that these functions do not benefit from the Psalm type annotations currently.

Please do reach out if there are any questions!